### PR TITLE
MO-84: Apply CSoC logic from compliance scheme landing controller to the frontend scheme registration controller (for direct producers)

### DIFF
--- a/src/FrontendSchemeRegistration.UI.UnitTests/Controllers/FrontendSchemeRegistrationTestBase.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/Controllers/FrontendSchemeRegistrationTestBase.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
+using Microsoft.FeatureManagement;
 using Moq;
 using Newtonsoft.Json;
 using UI.Controllers.FrontendSchemeRegistration;
@@ -155,7 +156,9 @@ public abstract class FrontendSchemeRegistrationTestBase
             ResubmissionApplicationService.Object,
             AuthorizationService.Object,
             NotificationService.Object,
-            FakeTimeProvider);
+            FakeTimeProvider,
+            new Mock<IFeatureManager>().Object,
+            new OptionsWrapper<CsocOptions>(new CsocOptions()));
         SystemUnderTest.ControllerContext.HttpContext = _httpContextMock.Object;
         SystemUnderTest.TempData = tempDataDictionaryMock.Object;
     }

--- a/src/FrontendSchemeRegistration.UI.UnitTests/Controllers/HomePageSelfManagedTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/Controllers/HomePageSelfManagedTests.cs
@@ -57,6 +57,7 @@ public class HomePageSelfManagedTests : FrontendSchemeRegistrationTestBase
         _userData = new UserData
         {
             Id = _userId,
+            ServiceRole = "Basic User",
             Organisations =
             [
                 new Organisation

--- a/src/FrontendSchemeRegistration.UI/Controllers/FrontendSchemeRegistration/FrontendSchemeRegistrationController.cs
+++ b/src/FrontendSchemeRegistration.UI/Controllers/FrontendSchemeRegistration/FrontendSchemeRegistrationController.cs
@@ -18,7 +18,12 @@ using FrontendSchemeRegistration.UI.Services.Interfaces;
 
 namespace FrontendSchemeRegistration.UI.Controllers.FrontendSchemeRegistration;
 
+using Application.Enums;
 using Application.Extensions;
+using Application.Options;
+using Helpers;
+using Microsoft.Extensions.Options;
+using Microsoft.FeatureManagement;
 
 [SuppressMessage("Major Code Smell",
     "S107: A long parameter list can indicate that a new structure should be created to wrap the numerous parameters or that the function is doing too many",
@@ -31,7 +36,9 @@ public class FrontendSchemeRegistrationController(
     IResubmissionApplicationService resubmissionApplicationService,
     IAuthorizationService authorizationService,
     INotificationService notificationService,
-    TimeProvider timeProvider)
+    TimeProvider timeProvider,
+    IFeatureManager featureManager,
+    IOptions<CsocOptions> csocOptions)
     : Controller
 {
 
@@ -434,6 +441,9 @@ public class FrontendSchemeRegistrationController(
             [packagingResubmissionPeriod?.DataPeriod], session.RegistrationSession.SelectedComplianceScheme?.Id);
         
         await Task.WhenAll(registrationApplicationYearViewModelsTask, resubmissionApplicationDetailsTask);
+        
+        var isApprovedUser = userData.ServiceRole.Parse<ServiceRole>().In(ServiceRole.Delegated, ServiceRole.Approved);
+        var now = timeProvider.GetLocalNow().DateTime;
 
         // Note: We are reading desired values using existing service to avoid SonarQube issue for adding 8th parameter in the constructor.
         var viewModel = new HomePageSelfManagedViewModel
@@ -445,7 +455,8 @@ public class FrontendSchemeRegistrationController(
             ResubmissionTaskListViewModel = resubmissionApplicationDetailsTask.Result.ToResubmissionTaskListViewModel(organisation),
             RegistrationApplications = registrationApplicationYearViewModelsTask.Result.SelectMany(ray => ray.Applications),
             PackagingResubmissionPeriod = packagingResubmissionPeriod,
-            ComplianceYear = timeProvider.GetUtcNow().GetComplianceYear().ToString()
+            ComplianceYear = timeProvider.GetUtcNow().GetComplianceYear().ToString(),
+            CsocViewModel = await CsocHelper.CreateViewModel(featureManager, isApprovedUser, organisation, now, csocOptions.Value)
         };
 
         var notificationsList = await notificationService.GetCurrentUserNotifications(organisation.Id.Value, userData.Id!.Value);

--- a/src/FrontendSchemeRegistration.UI/ViewModels/HomePageSelfManagedViewModel.cs
+++ b/src/FrontendSchemeRegistration.UI/ViewModels/HomePageSelfManagedViewModel.cs
@@ -30,6 +30,8 @@ public class HomePageSelfManagedViewModel
     public IEnumerable<RegistrationApplicationViewModel> RegistrationApplications { get; set; } = []; 
 
     public SubmissionPeriod PackagingResubmissionPeriod { get; set; }
+    
+    public CsocViewModel? CsocViewModel { get; set; }
 }
 
 [ExcludeFromCodeCoverage]

--- a/src/FrontendSchemeRegistration.UI/Views/FrontendSchemeRegistration/HomePageSelfManaged.cshtml
+++ b/src/FrontendSchemeRegistration.UI/Views/FrontendSchemeRegistration/HomePageSelfManaged.cshtml
@@ -174,7 +174,9 @@
                         <ul class="govuk-list govuk-list--bullet">
                             <li>@Localizer["prn_unordered_list_point_1"]</li>
                             <li>@Localizer["prn_unordered_list_point_2"]</li>
+                            @await Html.PartialAsync("Partials/Csoc/_LandingBullet", Model.CsocViewModel)
                         </ul>
+                        @await Html.PartialAsync("Partials/Csoc/_LandingParagraph", Model.CsocViewModel)
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
CSoC logic has only been applied to the compliance scheme controller. I thought there was only one layout! Turns out not.

This PR still needs some snapshot tests.