### PR TITLE
MO-86: Integrate submit statement/certificate url to waste obligations frontend

### DIFF
--- a/src/FrontendSchemeRegistration.Application/Options/CsocOptions.cs
+++ b/src/FrontendSchemeRegistration.Application/Options/CsocOptions.cs
@@ -7,5 +7,5 @@ public class CsocOptions
 {
     public const string ConfigSection = "Csoc";
     
-    public string? UnderstandingObligationsEndpoint { get; set; }
+    public string? WasteObligationsBaseAddress { get; set; }
 }

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Infrastructure/ConfigBuilder.cs
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Infrastructure/ConfigBuilder.cs
@@ -19,7 +19,10 @@ public static class ConfigBuilder
                 new KeyValuePair<string,string>("PaymentFacadeApi:BaseUrl", "http://localhost:9091"),
                 new KeyValuePair<string,string>("EprAuthorizationConfig:FacadeBaseUrl", "http://localhost:9091/api/"),
                 new KeyValuePair<string,string>("AccountsFacadeAPI:BaseEndpoint", "http://localhost:9091/api/"),
-                new KeyValuePair<string,string>("StartupUtcTimestampOverride", "2026-03-27T08:58:00Z")
+                new KeyValuePair<string,string>("StartupUtcTimestampOverride", "2026-03-27T08:58:00Z"),
+                new KeyValuePair<string,string>(
+                    "Csoc:UnderstandingObligationsEndpoint",
+                    "https://understanding-obligations")
             ]
         };
         

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Infrastructure/ConfigBuilder.cs
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Infrastructure/ConfigBuilder.cs
@@ -21,7 +21,7 @@ public static class ConfigBuilder
                 new KeyValuePair<string,string>("AccountsFacadeAPI:BaseEndpoint", "http://localhost:9091/api/"),
                 new KeyValuePair<string,string>("StartupUtcTimestampOverride", "2026-03-27T08:58:00Z"),
                 new KeyValuePair<string,string>(
-                    "Csoc:UnderstandingObligationsEndpoint",
+                    "Csoc:WasteObligationsBaseAddress",
                     "https://understanding-obligations")
             ]
         };

--- a/src/FrontendSchemeRegistration.UI.UnitTests/Helpers/CsocHelperTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/Helpers/CsocHelperTests.cs
@@ -167,4 +167,28 @@ public class CsocHelperTests
         result?.WasteObligationsBaseAddress.Should()
             .Be($"https://understanding-obligations/compliance/{organisationId}/statement?year={now.GetComplianceYear()}");
     }
+
+    [Test]
+    public async Task CreateViewModel_WhenOrganisationIsNeitherDirectProducerNorComplianceScheme_ShouldUseBaseAddress()
+    {
+        MockFeatureManager.Setup(x => x.IsEnabledAsync(FeatureFlags.CsocEnabled)).ReturnsAsync(true);
+        var organisationId = Guid.NewGuid();
+        var now = DateTime.Now;
+
+        var result = await CsocHelper.CreateViewModel(
+            MockFeatureManager.Object,
+            isApprovedUser: true,
+            new Organisation
+            {
+                Id = organisationId
+            },
+            now,
+            new CsocOptions
+            {
+                WasteObligationsBaseAddress = "https://understanding-obligations"
+            });
+
+        result.Should().NotBeNull();
+        result?.WasteObligationsBaseAddress.Should().Be("https://understanding-obligations");
+    }
 }

--- a/src/FrontendSchemeRegistration.UI.UnitTests/Helpers/CsocHelperTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/Helpers/CsocHelperTests.cs
@@ -57,7 +57,7 @@ public class CsocHelperTests
             now,
             new CsocOptions
             {
-                UnderstandingObligationsEndpoint = "href"
+                WasteObligationsBaseAddress = "href"
             });
 
         result.Should().NotBeNull();
@@ -66,7 +66,7 @@ public class CsocHelperTests
         result?.IsDirectProducer.Should().BeTrue();
         result?.SubmissionDeadline.Should().BeAfter(now);
         result?.ComplianceYear.Should().Be(now.GetComplianceYear());
-        result?.UnderstandingObligationsEndpoint.Should()
+        result?.WasteObligationsBaseAddress.Should()
             .Be($"href/compliance/{organisationId}/certificate?year={now.GetComplianceYear()}");
     }
     
@@ -86,7 +86,7 @@ public class CsocHelperTests
             now,
             new CsocOptions
             {
-                UnderstandingObligationsEndpoint = "href"
+                WasteObligationsBaseAddress = "href"
             },
             overallStatus is null ? null : new PrnObligationViewModel
             {
@@ -138,7 +138,7 @@ public class CsocHelperTests
     }
 
     [Test]
-    public async Task CreateViewModel_WhenOrganisationIsComplianceScheme_ShouldUseStatementUnderstandingObligationsEndpoint()
+    public async Task CreateViewModel_WhenOrganisationIsComplianceScheme_ShouldUseStatementWasteObligationsBaseAddress()
     {
         MockFeatureManager.Setup(x => x.IsEnabledAsync(FeatureFlags.CsocEnabled)).ReturnsAsync(true);
         var organisationId = Guid.NewGuid();
@@ -155,7 +155,7 @@ public class CsocHelperTests
             now,
             new CsocOptions
             {
-                UnderstandingObligationsEndpoint = "https://understanding-obligations"
+                WasteObligationsBaseAddress = "https://understanding-obligations"
             },
             new PrnObligationViewModel
             {
@@ -164,7 +164,7 @@ public class CsocHelperTests
             });
 
         result.Should().NotBeNull();
-        result?.UnderstandingObligationsEndpoint.Should()
+        result?.WasteObligationsBaseAddress.Should()
             .Be($"https://understanding-obligations/compliance/{organisationId}/statement?year={now.GetComplianceYear()}");
     }
 }

--- a/src/FrontendSchemeRegistration.UI.UnitTests/Helpers/CsocHelperTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/Helpers/CsocHelperTests.cs
@@ -8,6 +8,8 @@ using EPR.Common.Authorization.Models;
 using FluentAssertions;
 using Microsoft.FeatureManagement;
 using Moq;
+using System;
+using UI.Constants;
 using UI.Helpers;
 using UI.ViewModels.Prns;
 
@@ -42,11 +44,16 @@ public class CsocHelperTests
     {
         MockFeatureManager.Setup(x => x.IsEnabledAsync(FeatureFlags.CsocEnabled)).ReturnsAsync(true);
         var now = DateTime.Now;
+        var organisationId = Guid.NewGuid();
         
         var result = await CsocHelper.CreateViewModel(
             MockFeatureManager.Object, 
             isApprovedUser: true, 
-            new Organisation(), 
+            new Organisation
+            {
+                Id = organisationId,
+                OrganisationRole = OrganisationRoles.Producer
+            }, 
             now,
             new CsocOptions
             {
@@ -56,10 +63,11 @@ public class CsocHelperTests
         result.Should().NotBeNull();
         result?.IsApprovedUser.Should().BeTrue();
         result?.IsComplianceScheme.Should().BeFalse();
-        result?.IsDirectProducer.Should().BeFalse();
+        result?.IsDirectProducer.Should().BeTrue();
         result?.SubmissionDeadline.Should().BeAfter(now);
         result?.ComplianceYear.Should().Be(now.GetComplianceYear());
-        result?.UnderstandingObligationsEndpoint.Should().Be("href");
+        result?.UnderstandingObligationsEndpoint.Should()
+            .Be($"href/compliance/{organisationId}/certificate?year={now.GetComplianceYear()}");
     }
     
     [TestCase(null, false)]
@@ -127,5 +135,36 @@ public class CsocHelperTests
 
         result.Should().NotBeNull();
         result?.ComplianceDeclarationStatus.Should().BeNull();
+    }
+
+    [Test]
+    public async Task CreateViewModel_WhenOrganisationIsComplianceScheme_ShouldUseStatementUnderstandingObligationsEndpoint()
+    {
+        MockFeatureManager.Setup(x => x.IsEnabledAsync(FeatureFlags.CsocEnabled)).ReturnsAsync(true);
+        var organisationId = Guid.NewGuid();
+        var now = DateTime.Now;
+
+        var result = await CsocHelper.CreateViewModel(
+            MockFeatureManager.Object,
+            isApprovedUser: true,
+            new Organisation
+            {
+                Id = organisationId,
+                OrganisationRole = OrganisationRoles.ComplianceScheme
+            },
+            now,
+            new CsocOptions
+            {
+                UnderstandingObligationsEndpoint = "https://understanding-obligations"
+            },
+            new PrnObligationViewModel
+            {
+                OverallStatus = ObligationStatus.Met,
+                ComplianceDeclarationStatus = ComplianceDeclarationStatus.Cancelled
+            });
+
+        result.Should().NotBeNull();
+        result?.UnderstandingObligationsEndpoint.Should()
+            .Be($"https://understanding-obligations/compliance/{organisationId}/statement?year={now.GetComplianceYear()}");
     }
 }

--- a/src/FrontendSchemeRegistration.UI/Helpers/CsocHelper.cs
+++ b/src/FrontendSchemeRegistration.UI/Helpers/CsocHelper.cs
@@ -33,8 +33,8 @@ public static class CsocHelper
             IsComplianceScheme = organisation.IsComplianceScheme(),
             SubmissionDeadline = now.GetCsocSubmissionDeadline(),
             ComplianceYear = complianceYear,
-            UnderstandingObligationsEndpoint = GetUnderstandingObligationsEndpoint(
-                options.UnderstandingObligationsEndpoint,
+            WasteObligationsBaseAddress = GetWasteObligationsBaseAddress(
+                options.WasteObligationsBaseAddress,
                 organisation.Id,
                 organisation.IsComplianceScheme(),
                 organisation.IsDirectProducer(),
@@ -45,7 +45,7 @@ public static class CsocHelper
         };
     }
 
-    private static string? GetUnderstandingObligationsEndpoint(
+    private static string? GetWasteObligationsBaseAddress(
         string? baseEndpoint,
         Guid? organisationId,
         bool isComplianceScheme,

--- a/src/FrontendSchemeRegistration.UI/Helpers/CsocHelper.cs
+++ b/src/FrontendSchemeRegistration.UI/Helpers/CsocHelper.cs
@@ -58,11 +58,15 @@ public static class CsocHelper
             return baseEndpoint;
         }
 
-        var documentType = isComplianceScheme
-            ? "statement"
-            : isDirectProducer
-                ? "certificate"
-                : null;
+        string? documentType = null;
+        if (isComplianceScheme)
+        {
+            documentType = "statement";
+        }
+        else if (isDirectProducer)
+        {
+            documentType = "certificate";
+        }
 
         if (documentType is null)
         {

--- a/src/FrontendSchemeRegistration.UI/Helpers/CsocHelper.cs
+++ b/src/FrontendSchemeRegistration.UI/Helpers/CsocHelper.cs
@@ -23,17 +23,53 @@ public static class CsocHelper
         var enabled = await featureManager.IsEnabledAsync(FeatureFlags.CsocEnabled);
         if (!enabled) return null;
 
+        var complianceYear = now.GetComplianceYear();
+        var complianceDeclarationStatus = prnObligationViewModel?.ComplianceDeclarationStatus;
+
         return new CsocViewModel
         {
             IsApprovedUser = isApprovedUser,
             IsDirectProducer = organisation.IsDirectProducer(),
             IsComplianceScheme = organisation.IsComplianceScheme(),
             SubmissionDeadline = now.GetCsocSubmissionDeadline(),
-            ComplianceYear = now.GetComplianceYear(),
-            UnderstandingObligationsEndpoint = options.UnderstandingObligationsEndpoint,
+            ComplianceYear = complianceYear,
+            UnderstandingObligationsEndpoint = GetUnderstandingObligationsEndpoint(
+                options.UnderstandingObligationsEndpoint,
+                organisation.Id,
+                organisation.IsComplianceScheme(),
+                organisation.IsDirectProducer(),
+                complianceYear),
             IsObligationDataSubmitted = prnObligationViewModel is not null &&
                                         prnObligationViewModel.OverallStatus != ObligationStatus.NoDataYet,
-            ComplianceDeclarationStatus = prnObligationViewModel?.ComplianceDeclarationStatus
+            ComplianceDeclarationStatus = complianceDeclarationStatus
         };
+    }
+
+    private static string? GetUnderstandingObligationsEndpoint(
+        string? baseEndpoint,
+        Guid? organisationId,
+        bool isComplianceScheme,
+        bool isDirectProducer,
+        int complianceYear)
+    {
+        if (string.IsNullOrWhiteSpace(baseEndpoint) ||
+            !organisationId.HasValue)
+        {
+            return baseEndpoint;
+        }
+
+        var documentType = isComplianceScheme
+            ? "statement"
+            : isDirectProducer
+                ? "certificate"
+                : null;
+
+        if (documentType is null)
+        {
+            return baseEndpoint;
+        }
+
+        var normalizedBaseEndpoint = baseEndpoint.TrimEnd('/');
+        return $"{normalizedBaseEndpoint}/compliance/{organisationId.Value}/{documentType}?year={complianceYear}";
     }
 }

--- a/src/FrontendSchemeRegistration.UI/ViewModels/CsocViewModel.cs
+++ b/src/FrontendSchemeRegistration.UI/ViewModels/CsocViewModel.cs
@@ -11,7 +11,7 @@ public class CsocViewModel
     public bool IsComplianceScheme { get; set; }
     public DateTime SubmissionDeadline { get; set; }
     public int ComplianceYear { get; set; }
-    public string? UnderstandingObligationsEndpoint { get; set; }
+    public string? WasteObligationsBaseAddress { get; set; }
     public bool IsObligationDataSubmitted { get; set; }
     public ComplianceDeclarationStatus? ComplianceDeclarationStatus { get; set; }
 }

--- a/src/FrontendSchemeRegistration.UI/Views/Shared/Partials/Csoc/_ObligationsHome.cshtml
+++ b/src/FrontendSchemeRegistration.UI/Views/Shared/Partials/Csoc/_ObligationsHome.cshtml
@@ -23,10 +23,10 @@
             <div class="govuk-card-body">
                 <h2 class="govuk-heading-m">@Localizer[$"{statusKey}_heading_{actorKey}"]</h2>
                 <p class="govuk-body">@string.Format(Localizer[$"{statusKey}_paragraph_{actorKey}"].Value, Model.ComplianceYear, Model.SubmissionDeadline)</p>
-                @if (Model.IsApprovedUser && Model.UnderstandingObligationsEndpoint is not null)
+                @if (Model.IsApprovedUser && Model.WasteObligationsBaseAddress is not null)
                 {
                     <div class="govuk-button-group">
-                        <a class="govuk-button govuk-button--secondary" href="@Model.UnderstandingObligationsEndpoint"
+                        <a class="govuk-button govuk-button--secondary" href="@Model.WasteObligationsBaseAddress"
                            role="button" data-module="govuk-button">@Localizer[$"{statusKey}_button_{actorKey}"]</a>
                     </div>
                 }

--- a/src/FrontendSchemeRegistration.UI/appsettings.json
+++ b/src/FrontendSchemeRegistration.UI/appsettings.json
@@ -86,7 +86,7 @@
     "UseGraphApiForExtendedUserClaims": false,
     "EnableRegistrationFeeV2": false,
     "DisplayCsoSmallProducerRegistration": false,
-    "CsoRegistrationEnabled" : true,
+    "CsoRegistrationEnabled": true,
     "ShowNotificationBanner": true,
     "CsocEnabled": false
   },
@@ -452,14 +452,14 @@
       "OnlinePaymentsEndpoint": "online-payments",
       "ProducerRegistrationFeesEndpoint": "producer/registration-fee",
       "ComplianceSchemeRegistrationFeesEndpoint": "compliance-scheme/registration-fee",
-      "ProducerResubmissionFeesEndpoint":  "producer/resubmission-fee",
-      "ComplianceSchemeResubmissionFeesEndpoint":  "compliance-scheme/resubmission-fees"
+      "ProducerResubmissionFeesEndpoint": "producer/resubmission-fee",
+      "ComplianceSchemeResubmissionFeesEndpoint": "compliance-scheme/resubmission-fees"
     }
   },
   "Fibre": {
     "LaunchDate": "2026-04-13"
   },
   "Csoc": {
-    "UnderstandingObligationsEndpoint": "https://understanding-obligations"
+    "UnderstandingObligationsEndpoint": "http://localhost:3000"
   }
 }

--- a/src/FrontendSchemeRegistration.UI/appsettings.json
+++ b/src/FrontendSchemeRegistration.UI/appsettings.json
@@ -460,6 +460,6 @@
     "LaunchDate": "2026-04-13"
   },
   "Csoc": {
-    "UnderstandingObligationsEndpoint": "http://localhost:3000"
+    "WasteObligationsBaseAddress": "http://localhost:3000"
   }
 }


### PR DESCRIPTION
Integrate `packaging-frontend` with `waste-obligations-frontend`

**AC1: Display new about your certificate/statement page** 
_GIVEN_ that a DP/CSO user has loaded the Obligations page 
_AND_ the CSOC has not been submitted  
_WHEN_ the user clicks the Submit certificate/statement button on the new tile
_THEN_ load a new ‘About your certificate/statement’ page with the content given in the description 

related PR: https://github.com/DEFRA/waste-obligations-frontend/pull/14

