### PR TITLE
Feature/sub 235 warn if clr weight greater than overall weight of packaging material

### DIFF
--- a/src/FrontendSchemeRegistration.UI.UnitTests/Helpers/ErrorReportHelpersTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/Helpers/ErrorReportHelpersTests.cs
@@ -62,8 +62,9 @@ public class ErrorReportHelpersTests
     [TestCase("en-GB", "WarningIssue", "Warning")]
 
     // Welsh
-    [TestCase("cy-GB", "60", "Gwiriwch bwysau'r deunydd pecynwaith ar gyfer pob rhes i'r sefydliad yma. Os yw cyfanswm y flwyddyn adrodd rhwng 25,000kg a 50,000kg, efallai mai dim ond fel sefydliad bach y bydd angen i'r sefydliad yma gofrestru yn y flwyddyn ganlynol.")]
-    [TestCase("cy-GB", "63", "Yn achos gwastraff defnyddwyr hunan-reoledig (CW), mae'n bosibl na fyddwch chi'n gallu gwrthbwyso'ch pecynwaith eich hunan yn erbyn alwminiwm (AL), gwydr (GL), papur neu gerdyn (PC), neu ddur (ST). I wirio pa ddeunyddiau pecynwaith y gallwch eu gwrthbwyso, bydd angen ichi gysylltu â rheoleiddiwr amgylcheddol eich gwlad.")]    
+    [TestCase("cy-GB", "60", "Mae'n ymddangos bod cyfanswm pwysau’r pecynwaith y rhoddwyd gwybod amdano yn is na 25,000kg, sef y trothwy ar gyfer cynhyrchydd bach. Gwiriwch bwysau'r deunydd pecynwaith ar gyfer pob rhes ar gyfer y sefydliad yma. Os yw'r ffigur yn gywir, rydych chi'n dal yn cael ei gyflwyno.")]
+    [TestCase("cy-GB", "63", "Yn achos gwastraff defnyddwyr hunan-reoledig (CW), mae'n bosibl na fyddwch chi'n gallu gwrthbwyso'ch pecynwaith eich hunan yn erbyn alwminiwm (AL), gwydr (GL), papur neu gerdyn (PC), neu ddur (ST). I wirio pa ddeunyddiau pecynwaith y gallwch eu gwrthbwyso, bydd angen ichi gysylltu â rheoleiddiwr amgylcheddol eich gwlad.")]
+    [TestCase("cy-GB", "74", "Ni chaiff pwysau dolen gaeedig fod yn fwy na chyfanswm y pwysau y rhoddwyd gwybod amdano ar gyfer y deunydd pecynwaith yma.")]
 
     public void ToErrorReportRows_ConvertsValidationErrorsToErrorRowsWithMessage_WhenCalled(
         string culture, string errorCode, string expectedMessage)

--- a/src/FrontendSchemeRegistration.UI.UnitTests/Helpers/ErrorReportHelpersTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/Helpers/ErrorReportHelpersTests.cs
@@ -56,7 +56,8 @@ public class ErrorReportHelpersTests
     [TestCase("en-GB", "59", "Packaging material weight is less than 100. Check all packaging weights are in kg and not tonnes.")]
     [TestCase("en-GB", "60", "The total packaging weight reported appears to be below 25,000kg, which is the threshold for a small producer. Check the packaging material weight for all rows for this organisation. You can still submit if the figure is correct.")]
     [TestCase("en-GB", "62", "Only one packaging material reported for this organisation. Check you have entered all packaging materials. All must be reported separately.")]
-    [TestCase("en-GB", "63", "For self-managed consumer waste (CW), you may not be able to offset your own packaging against aluminium (AL), glass (GL), paper or card (PC), or steel (ST). To check what packaging materials you can offset, you'll need to contact your nation's environmental regulator.")]    
+    [TestCase("en-GB", "63", "For self-managed consumer waste (CW), you may not be able to offset your own packaging against aluminium (AL), glass (GL), paper or card (PC), or steel (ST). To check what packaging materials you can offset, you'll need to contact your nation's environmental regulator.")]
+    [TestCase("en-GB", "74", "Closed loop weight cannot exceed the total weight reported for this packaging material.")]
     [TestCase("en-GB", "ErrorIssue", "Error")]
     [TestCase("en-GB", "WarningIssue", "Warning")]
 

--- a/src/FrontendSchemeRegistration.UI/Resources/ErrorCodes.cy.resx
+++ b/src/FrontendSchemeRegistration.UI/Resources/ErrorCodes.cy.resx
@@ -439,4 +439,7 @@ Darllenwch y canllawiau ar sut i greu’ch ffeil manylion sefydliad. Ar ôl ichi
   <data name="908" xml:space="preserve">
     <value>Rhaid i ddosbarth y deunydd pacio fod yn wag.</value>
   </data>
+  <data name="74" xml:space="preserve">
+    <value>Ni chaiff pwysau dolen gaeedig fod yn fwy na chyfanswm y pwysau y rhoddwyd gwybod amdano ar gyfer y deunydd pecynwaith yma.</value>
+  </data>
 </root>

--- a/src/FrontendSchemeRegistration.UI/Resources/ErrorCodes.cy.resx
+++ b/src/FrontendSchemeRegistration.UI/Resources/ErrorCodes.cy.resx
@@ -329,7 +329,7 @@ Darllenwch y canllawiau ar sut i greu’ch ffeil manylion sefydliad. Ar ôl ichi
     <value>Nid yw ID Atodol yn perthyn i unrhyw sefydliad.</value>
   </data>
   <data name="60" xml:space="preserve">
-    <value>Gwiriwch bwysau'r deunydd pecynwaith ar gyfer pob rhes i'r sefydliad yma. Os yw cyfanswm y flwyddyn adrodd rhwng 25,000kg a 50,000kg, efallai mai dim ond fel sefydliad bach y bydd angen i'r sefydliad yma gofrestru yn y flwyddyn ganlynol.</value>
+    <value>Mae'n ymddangos bod cyfanswm pwysau’r pecynwaith y rhoddwyd gwybod amdano yn is na 25,000kg, sef y trothwy ar gyfer cynhyrchydd bach. Gwiriwch bwysau'r deunydd pecynwaith ar gyfer pob rhes ar gyfer y sefydliad yma. Os yw'r ffigur yn gywir, rydych chi'n dal yn cael ei gyflwyno.</value>
   </data>
   <data name="90" xml:space="preserve">
     <value>Unedau Pecynwaith Trosiannol yn Annilys</value>

--- a/src/FrontendSchemeRegistration.UI/Resources/ErrorCodes.en.resx
+++ b/src/FrontendSchemeRegistration.UI/Resources/ErrorCodes.en.resx
@@ -445,4 +445,7 @@ Read the guidance about how to create your organisation details file. Once youâ€
   <data name="109" xml:space="preserve">
     <value>Recyclability codes are applicable only for HH, PB and HDC-GL packaging material types for 2025 onwards submissions for large organisations (L)</value>
   </data>
+  <data name="74" xml:space="preserve">
+    <value>Closed loop weight cannot exceed the total weight reported for this packaging material.</value>
+  </data>
 </root>


### PR DESCRIPTION
Add new error code "74" and English and Welsh warning text related to CLR weight for a particular material type exceeding the reported weight for the material type overall. Also added the Welsh translation for an earlier release now that it is available (SUB-236). Updated the ErrorReportHelper tests to reflect these changes.