### PR TITLE
Bugfix/sub 168 registration file deadline not set

### DIFF
--- a/src/FrontendSchemeRegistration.UI.UnitTests/Controllers/FileReUploadCompanyDetailsConfirmationControllerTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/Controllers/FileReUploadCompanyDetailsConfirmationControllerTests.cs
@@ -1,10 +1,12 @@
 ﻿namespace FrontendSchemeRegistration.UI.UnitTests.Controllers;
 
+using System.Collections.ObjectModel;
 using EPR.Common.Authorization.Models;
 using EPR.Common.Authorization.Sessions;
 using FluentAssertions;
 using Application.DTOs.Submission;
 using Application.DTOs.UserAccount;
+using Application.Options.RegistrationPeriodPatterns;
 using FrontendSchemeRegistration.Application.Enums;
 using FrontendSchemeRegistration.Application.Services.Interfaces;
 using FrontendSchemeRegistration.UI.Controllers;
@@ -19,7 +21,7 @@ using Microsoft.Extensions.Primitives;
 using Moq;
 using Organisation = EPR.Common.Authorization.Models.Organisation;
 using FrontendSchemeRegistration.Application.Constants;
-using FrontendSchemeRegistration.UI.Services;
+using Microsoft.Extensions.Time.Testing;
 
 [TestFixture]
 public class FileReUploadCompanyDetailsConfirmationControllerTests
@@ -30,6 +32,9 @@ public class FileReUploadCompanyDetailsConfirmationControllerTests
     private Mock<IUserAccountService> _userAccountServiceMock;
     private FileReUploadCompanyDetailsConfirmationController _systemUnderTest;
     private Mock<ISessionManager<FrontendSchemeRegistrationSession>> _sessionManagerMock;
+    private Mock<IRegistrationPeriodProvider> _registrationPeriodProviderMock;
+    private FakeTimeProvider _dateTimeProvider;
+    private const int RegistrationYear = 2026;
 
     [SetUp]
     public void SetUp()
@@ -57,11 +62,17 @@ public class FileReUploadCompanyDetailsConfirmationControllerTests
 
         _submissionServiceMock = new Mock<ISubmissionService>();
         _userAccountServiceMock = new Mock<IUserAccountService>();
+        _registrationPeriodProviderMock = new Mock<IRegistrationPeriodProvider>();
+        
+        _dateTimeProvider = new FakeTimeProvider();
+        _dateTimeProvider.SetUtcNow(new DateTime(2026, 1, 1));
+        _registrationPeriodProviderMock.Setup(x => x.GetAllRegistrationWindows(It.IsAny<bool>())).Returns(
+            CreateRegistrationWindows(WindowType.DirectSmallProducer, RegistrationYear, null, null, null));
 
         _systemUnderTest =
             new FileReUploadCompanyDetailsConfirmationController(
                 _submissionServiceMock.Object,
-                _userAccountServiceMock.Object, _sessionManagerMock.Object);
+                _userAccountServiceMock.Object, _sessionManagerMock.Object, _registrationPeriodProviderMock.Object);
 
         _systemUnderTest.ControllerContext = new ControllerContext
         {
@@ -572,5 +583,21 @@ public class FileReUploadCompanyDetailsConfirmationControllerTests
         backLink.Should().Contain(PagePaths.RegistrationTaskList);
         backLink.Should().Contain("registrationjourney");
         backLink.Should().Contain("registrationyear");
+    }
+    
+    private IReadOnlyCollection<RegistrationWindow> CreateRegistrationWindows(WindowType windowType, int? registrationYear = RegistrationYear, DateTime? openingDateOffset = null,
+        DateTime? deadlineDateOffset = null, DateTime? closingDateOffset = null)
+    {
+        var today = DateTime.UtcNow;
+        var opening = openingDateOffset ?? new DateTime(RegistrationYear, today.AddDays(-1).Month, today.AddDays(-1).Day);
+        var deadline = deadlineDateOffset ?? new DateTime(RegistrationYear, today.Month, today.Day);
+        var closing = closingDateOffset ?? new DateTime(RegistrationYear, today.AddDays(1).Month, today.AddDays(1).Day);
+
+        var registrationWindows = new List<RegistrationWindow>
+        {
+            new(_dateTimeProvider, windowType, registrationYear.GetValueOrDefault(RegistrationYear), opening, deadline, closing)
+        };
+        
+        return new ReadOnlyCollection<RegistrationWindow>(registrationWindows);
     }
 }

--- a/src/FrontendSchemeRegistration.UI.UnitTests/Controllers/FileReUploadCompanyDetailsConfirmationControllerTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/Controllers/FileReUploadCompanyDetailsConfirmationControllerTests.cs
@@ -26,7 +26,6 @@ using Microsoft.Extensions.Time.Testing;
 [TestFixture]
 public class FileReUploadCompanyDetailsConfirmationControllerTests
 {
-    private static readonly DateTime SubmissionDeadline = DateTime.UtcNow;
     private static readonly Guid SubmissionId = Guid.NewGuid();
     private Mock<ISubmissionService> _submissionServiceMock;
     private Mock<IUserAccountService> _userAccountServiceMock;
@@ -35,17 +34,20 @@ public class FileReUploadCompanyDetailsConfirmationControllerTests
     private Mock<IRegistrationPeriodProvider> _registrationPeriodProviderMock;
     private FakeTimeProvider _dateTimeProvider;
     private const int RegistrationYear = 2026;
-
+    
     [SetUp]
     public void SetUp()
     {
+        _dateTimeProvider = new FakeTimeProvider();
+        _dateTimeProvider.SetUtcNow(new DateTime(2026, 1, 1));
+        
         _sessionManagerMock = new Mock<ISessionManager<FrontendSchemeRegistrationSession>>();
         _sessionManagerMock.Setup(x => x.GetSessionAsync(It.IsAny<ISession>()))
             .ReturnsAsync(new FrontendSchemeRegistrationSession
             {
                 RegistrationSession = new RegistrationSession
                 {
-                    SubmissionDeadline = SubmissionDeadline
+                    SubmissionDeadline = _dateTimeProvider.GetUtcNow().DateTime
                 },
                 UserData = new UserData
                 {
@@ -64,8 +66,6 @@ public class FileReUploadCompanyDetailsConfirmationControllerTests
         _userAccountServiceMock = new Mock<IUserAccountService>();
         _registrationPeriodProviderMock = new Mock<IRegistrationPeriodProvider>();
         
-        _dateTimeProvider = new FakeTimeProvider();
-        _dateTimeProvider.SetUtcNow(new DateTime(2026, 1, 1));
         _registrationPeriodProviderMock.Setup(x => x.GetAllRegistrationWindows(It.IsAny<bool>())).Returns(
             CreateRegistrationWindows(WindowType.DirectSmallProducer, RegistrationYear, null, null, null));
 
@@ -184,7 +184,7 @@ public class FileReUploadCompanyDetailsConfirmationControllerTests
             PartnersFileName = partnersFileName,
             PartnersFileUploadDate = partnersUploadDate.ToReadableDate(),
             PartnersFileUploadedBy = fullName,
-            SubmissionDeadline = SubmissionDeadline.ToReadableDate(),
+            SubmissionDeadline = _dateTimeProvider.GetUtcNow().DateTime.ToReadableLongMonthDeadlineDate(),
             IsSubmitted = false,
             HasValidfile = true,
             Status = SubmissionPeriodStatus.FileUploaded,
@@ -258,7 +258,7 @@ public class FileReUploadCompanyDetailsConfirmationControllerTests
             {
                 RegistrationSession = new RegistrationSession
                 {
-                    SubmissionDeadline = SubmissionDeadline,
+                    SubmissionDeadline = _dateTimeProvider.GetUtcNow().DateTime,
                     IsFileUploadJourneyInvokedViaRegistration = true
                 },
                 UserData = new UserData
@@ -294,7 +294,7 @@ public class FileReUploadCompanyDetailsConfirmationControllerTests
             PartnersFileName = partnersFileName,
             PartnersFileUploadDate = partnersUploadDate.ToReadableDate(),
             PartnersFileUploadedBy = fullName,
-            SubmissionDeadline = SubmissionDeadline.ToReadableDate(),
+            SubmissionDeadline = _dateTimeProvider.GetUtcNow().DateTime.ToReadableLongMonthDeadlineDate(),
             IsSubmitted = false,
             HasValidfile = true,
             Status = SubmissionPeriodStatus.FileUploaded,
@@ -386,7 +386,7 @@ public class FileReUploadCompanyDetailsConfirmationControllerTests
             PartnersFileName = partnersFileName,
             PartnersFileUploadDate = submitDate.ToReadableDate(),
             PartnersFileUploadedBy = fullName,
-            SubmissionDeadline = SubmissionDeadline.ToReadableDate(),
+            SubmissionDeadline = _dateTimeProvider.GetUtcNow().DateTime.ToReadableLongMonthDeadlineDate(),
             IsSubmitted = true,
             HasValidfile = true,
             Status = SubmissionPeriodStatus.SubmittedToRegulator,
@@ -437,7 +437,7 @@ public class FileReUploadCompanyDetailsConfirmationControllerTests
             CompanyDetailsFileName = orgDetailsFileName,
             CompanyDetailsFileUploadDate = orgDetailsUploadDate.ToReadableDate(),
             CompanyDetailsFileUploadedBy = fullName,
-            SubmissionDeadline = SubmissionDeadline.ToReadableDate(),
+            SubmissionDeadline = _dateTimeProvider.GetUtcNow().DateTime.ToReadableLongMonthDeadlineDate(),
             HasValidfile = true,
             Status = SubmissionPeriodStatus.NotStarted,
             OrganisationRole = "Producer",
@@ -556,7 +556,7 @@ public class FileReUploadCompanyDetailsConfirmationControllerTests
             {
                 RegistrationSession = new RegistrationSession
                 {
-                    SubmissionDeadline = SubmissionDeadline,
+                    SubmissionDeadline = _dateTimeProvider.GetUtcNow().DateTime,
                     IsFileUploadJourneyInvokedViaRegistration = true,
                     IsResubmission = false
                 },
@@ -588,7 +588,7 @@ public class FileReUploadCompanyDetailsConfirmationControllerTests
     private IReadOnlyCollection<RegistrationWindow> CreateRegistrationWindows(WindowType windowType, int? registrationYear = RegistrationYear, DateTime? openingDateOffset = null,
         DateTime? deadlineDateOffset = null, DateTime? closingDateOffset = null)
     {
-        var today = DateTime.UtcNow;
+        var today = _dateTimeProvider.GetUtcNow().DateTime;
         var opening = openingDateOffset ?? new DateTime(RegistrationYear, today.AddDays(-1).Month, today.AddDays(-1).Day);
         var deadline = deadlineDateOffset ?? new DateTime(RegistrationYear, today.Month, today.Day);
         var closing = closingDateOffset ?? new DateTime(RegistrationYear, today.AddDays(1).Month, today.AddDays(1).Day);

--- a/src/FrontendSchemeRegistration.UI/Controllers/FileReUploadCompanyDetailsConfirmationController.cs
+++ b/src/FrontendSchemeRegistration.UI/Controllers/FileReUploadCompanyDetailsConfirmationController.cs
@@ -19,16 +19,18 @@ public class FileReUploadCompanyDetailsConfirmationController : Controller
     private readonly ISubmissionService _submissionService;
     private readonly IUserAccountService _accountService;
     private readonly ISessionManager<FrontendSchemeRegistrationSession> _sessionManager;
+    private readonly IRegistrationPeriodProvider _registrationPeriodProvider;
 
     public FileReUploadCompanyDetailsConfirmationController(
         ISubmissionService submissionService,
         IUserAccountService accountService,
-        ISessionManager<FrontendSchemeRegistrationSession> sessionManager)
+        ISessionManager<FrontendSchemeRegistrationSession> sessionManager,
+        IRegistrationPeriodProvider registrationPeriodProvider)
     {
         _submissionService = submissionService;
         _accountService = accountService;
         _sessionManager = sessionManager;
-
+        _registrationPeriodProvider = registrationPeriodProvider;
     }
 
     [HttpGet]
@@ -82,6 +84,14 @@ public class FileReUploadCompanyDetailsConfirmationController : Controller
             RegistrationJourney = registrationJourney
         };
 
+        var activeRegistrationWindows = _registrationPeriodProvider.GetAllRegistrationWindows(
+                session.RegistrationSession.UsingAComplianceScheme.GetValueOrDefault(false));
+        var currentWindow = activeRegistrationWindows.FirstOrDefault(x => x.RegistrationYear == registrationYear);
+        if (currentWindow != null)
+        {
+            model.SubmissionDeadline = currentWindow.DeadlineDate.ToReadableLongMonthDeadlineDate();
+        }
+        
         if (model.Status.Equals(SubmissionPeriodStatus.NotStarted) && !string.IsNullOrEmpty(submission.CompanyDetailsFileName))
         {
             var companyDetailsUploadedBy = await GetUsersName(submission.CompanyDetailsUploadedBy);


### PR DESCRIPTION
Add the submission deadline details to the view model used when re-uploading org details. The fix uses the existing registration provider to provide the required details based on the Registration Year already held in the current Registration Session.