### PR TITLE
copy for error message - clr not valid for small producer

### DIFF
--- a/src/FrontendSchemeRegistration.UI/Resources/CompanyDetailsSubmissionErrorCodes.cy.resx
+++ b/src/FrontendSchemeRegistration.UI/Resources/CompanyDetailsSubmissionErrorCodes.cy.resx
@@ -420,4 +420,7 @@
   <data name="934" xml:space="preserve">
     <value>Rhowch Ie neu Na ar gyfer cofrestru dolen gaeedig.</value>
   </data>
+  <data name="936" xml:space="preserve">
+    <value>[Welsh] Small producers cannot register for closed loop packaging waste</value>
+  </data>
 </root>

--- a/src/FrontendSchemeRegistration.UI/Resources/CompanyDetailsSubmissionErrorCodes.en.resx
+++ b/src/FrontendSchemeRegistration.UI/Resources/CompanyDetailsSubmissionErrorCodes.en.resx
@@ -420,4 +420,7 @@
   <data name="934" xml:space="preserve">
     <value>Enter Yes or No for closed loop registration.</value>
   </data>
+  <data name="936" xml:space="preserve">
+    <value>Small producers cannot register for closed loop packaging waste</value>
+  </data>
 </root>


### PR DESCRIPTION
Copy for error message that is shown when Small DP specifies closed_loop_registration='yes' in the Registration csv.