### PR TITLE
Feature/sub 250 add parent child link to subsidiaries

### DIFF
--- a/src/FrontendSchemeRegistration.Application/ClassMaps/ExportOrganisationAllSubsidiariesRowMap.cs
+++ b/src/FrontendSchemeRegistration.Application/ClassMaps/ExportOrganisationAllSubsidiariesRowMap.cs
@@ -10,6 +10,7 @@ public sealed class ExportOrganisationAllSubsidiariesRowMap : ClassMap<DTOs.Subs
     {
         Map(m => m.OrganisationName).Name("subsidiary_name");
         Map(m => m.OrganisationNumber).Name("subsidiary_id");
+        Map(m => m.ParentOrganisationNumber).Name("parent_id");
         Map(m => m.CompaniesHouseNumber).Name("companies_house_number");
     }
 }

--- a/src/FrontendSchemeRegistration.Application/DTOs/Subsidiary/OrganisationSubsidiaryList/RelationshipResponseModel.cs
+++ b/src/FrontendSchemeRegistration.Application/DTOs/Subsidiary/OrganisationSubsidiaryList/RelationshipResponseModel.cs
@@ -7,6 +7,8 @@ public class RelationshipResponseModel
 {
     public Guid? ParentOrganisationExternalId { get; set; }
 
+    public string ParentOrganisationNumber { get; set; }
+
     public string OrganisationNumber { get; set; }
 
     public string OrganisationName { get; set; }

--- a/src/FrontendSchemeRegistration.UI/Resources/Views/FileUploadSubsidiaries/AllSubsidiariesList.cy.resx
+++ b/src/FrontendSchemeRegistration.UI/Resources/Views/FileUploadSubsidiaries/AllSubsidiariesList.cy.resx
@@ -196,7 +196,7 @@
     <value>o fewn 28 diwrnod ar ôl y newid. Bydd angen ichi roi IDs yr is-gwmnïau er mwyn gwneud hyn.</value>
   </data>
   <data name="search_for_a_subsidiary_by" xml:space="preserve">
-    <value>Chwilio am is-gwmni yn ôl enw, ID neu rif Tŷ'r Cwmnïau</value>
+    <value>Chwilio am is-gwmni yn ôl enw, ID, parent ID neu rif Tŷ'r Cwmnïau</value>
   </data>
   <data name="clear_and_reset" xml:space="preserve">
     <value>Clirio ac ailosod</value>
@@ -205,7 +205,7 @@
     <value>Chwilio</value>
   </data>
   <data name="subsidiary_not_found_message" xml:space="preserve">
-    <value>Gwnewch yn siŵr eich bod wedi rhoi enw, ID neu Rif Tŷ'r Cwmni cywir yr is-gwmni. Os oes angen ichi ychwanegu is-gwmni at y rhiant-gwmni yma, defnyddiwch y broses uwchlwytho ffeil i greu ID is-gwmni ac wedyn diweddaru ac uwchlwytho'ch ffeil gofrestru.</value>
+    <value>Gwnewch yn siŵr eich bod wedi rhoi enw, ID, parent ID neu Rif Tŷ'r Cwmni cywir yr is-gwmni. Os oes angen ichi ychwanegu is-gwmni at y rhiant-gwmni yma, defnyddiwch y broses uwchlwytho ffeil i greu ID is-gwmni ac wedyn diweddaru ac uwchlwytho'ch ffeil gofrestru.</value>
   </data>
   <data name="subsidiary_not_found_resubmit_warning_text" xml:space="preserve">
     <value>Os oes angen ichi ychwanegu is-gwmni at y rhiant-gwmni yma, cliciwch ar y botwm ychwanegu un is-gwmni isod neu defnyddiwch uwchlwytho ffeil i greu ID is-gwmni ac wedyn diweddaru ac ailgyflwyno'ch ffeil gofrestru</value>

--- a/src/FrontendSchemeRegistration.UI/Resources/Views/FileUploadSubsidiaries/AllSubsidiariesList.cy.resx
+++ b/src/FrontendSchemeRegistration.UI/Resources/Views/FileUploadSubsidiaries/AllSubsidiariesList.cy.resx
@@ -171,6 +171,9 @@
   <data name="subsidiary_id" xml:space="preserve">
     <value>ID yr is-gwmni</value>
   </data>
+  <data name="parent_id" xml:space="preserve">
+    <value>Parent ID</value>
+  </data>
   <data name="subsidiary_name" xml:space="preserve">
     <value>Enw'r is-gwmni</value>
   </data>

--- a/src/FrontendSchemeRegistration.UI/Resources/Views/FileUploadSubsidiaries/AllSubsidiariesList.en.resx
+++ b/src/FrontendSchemeRegistration.UI/Resources/Views/FileUploadSubsidiaries/AllSubsidiariesList.en.resx
@@ -196,7 +196,7 @@
     <value>within 28 days of the change. You will need to enter the subsidiary IDs to do this.</value>
   </data>
     <data name="search_for_a_subsidiary_by" xml:space="preserve">
-    <value>Search for a Subsidiary by name, ID or Companies House number</value>
+    <value>Search for a Subsidiary by name, ID, parent ID or Companies House number</value>
   </data>
     <data name="clear_and_reset" xml:space="preserve">
     <value>Clear and reset</value>
@@ -205,7 +205,7 @@
     <value>Search</value>
   </data>
     <data name="subsidiary_not_found_message" xml:space="preserve">
-    <value>Make sure you entered the correct subsidiary name, ID or Companies House number. If you need to add a subsidiary to&lt;br /&gt;this parent company, use the file upload to create a subsidiary ID and then update and resubmit your registration file.</value>
+    <value>Make sure you entered the correct subsidiary name, ID, parent ID or Companies House number. If you need to add a subsidiary to&lt;br /&gt;this parent company, use the file upload to create a subsidiary ID and then update and resubmit your registration file.</value>
   </data>
     <data name="subsidiary_not_found_resubmit_warning_text" xml:space="preserve">
     <value>If you need to add a subsidiary to this parent company, click on add a single subsidiary button below or use the file upload to create a subsidiary ID and then update and resubmit your registration file.</value>

--- a/src/FrontendSchemeRegistration.UI/Resources/Views/FileUploadSubsidiaries/AllSubsidiariesList.en.resx
+++ b/src/FrontendSchemeRegistration.UI/Resources/Views/FileUploadSubsidiaries/AllSubsidiariesList.en.resx
@@ -171,6 +171,9 @@
     <data name="subsidiary_id" xml:space="preserve">
     <value>Subsidiary ID</value>
   </data>
+    <data name="parent_id" xml:space="preserve">
+    <value>Parent ID</value>
+  </data>
     <data name="subsidiary_name" xml:space="preserve">
     <value>Subsidiary name</value>
   </data>

--- a/src/FrontendSchemeRegistration.UI/Resources/Views/FileUploadSubsidiaries/AllSubsidiariesList.resx
+++ b/src/FrontendSchemeRegistration.UI/Resources/Views/FileUploadSubsidiaries/AllSubsidiariesList.resx
@@ -171,6 +171,9 @@
   <data name="subsidiary_id" xml:space="preserve">
     <value />
   </data>
+  <data name="parent_id" xml:space="preserve">
+    <value />
+  </data>
   <data name="subsidiary_name" xml:space="preserve">
     <value />
   </data>

--- a/src/FrontendSchemeRegistration.UI/Views/FileUploadSubsidiaries/AllSubsidiariesList.cshtml
+++ b/src/FrontendSchemeRegistration.UI/Views/FileUploadSubsidiaries/AllSubsidiariesList.cshtml
@@ -7,6 +7,7 @@
 
     var subsidiaryNameHeader = Localizer["subsidiary_name"];
     var subsidiaryIdHeader = Localizer["subsidiary_id"];
+    var parentIdHeader = Localizer["parent_id"];
     var companiesHouseNumberHeader = Localizer["companies_house_number"];
     var joinedHeader = Localizer["joined"];
     var reportingHeader = Localizer["reporting"];
@@ -125,6 +126,7 @@
                                     <tr class="govuk-table__row">
                                         <th scope="col" class="govuk-table__header">@subsidiaryNameHeader</th>
                                         <th scope="col" class="govuk-table__header no-wrap-text">@subsidiaryIdHeader</th>
+                                        <th scope="col" class="govuk-table__header no-wrap-text">@parentIdHeader</th>
                                         <th scope="col" class="govuk-table__header no-wrap-text">@companiesHouseNumberHeader</th>
                                         <feature name="@FeatureFlags.ShowSubsidiaryJoinerAndLeaverColumns">
                                             <th scope="col" class="govuk-table__header no-wrap-text govuk-!-padding-right-5">@joinedHeader</th>
@@ -141,6 +143,7 @@
                                         <tr class="govuk-table__row">
                                             <td class="govuk-table__cell break-word" data-heading="@subsidiaryNameHeader">@subsidiaryViewModel.OrganisationName</td>
                                             <td class="govuk-table__cell break-word" data-heading="@subsidiaryIdHeader">@subsidiaryViewModel.OrganisationNumber</td>
+                                            <td class="govuk-table__cell break-word" data-heading="@parentIdHeader">@subsidiaryViewModel.ParentOrganisationNumber</td>
                                             <td class="govuk-table__cell break-word" data-heading="@companiesHouseNumberHeader">
                                                 @(!string.IsNullOrWhiteSpace(subsidiaryViewModel.CompaniesHouseNumber) ? subsidiaryViewModel.CompaniesHouseNumber : Localizer["no_ch_number"])
                                             </td>


### PR DESCRIPTION
- Add subsidiary "parent ID" to default list of all subsidiaries
- Include "parent ID" in the downloadable list of subsidiaries as a CSV
- Add "parent ID" to the search parameters offered.
- Add additional english/welsh label and amend a couple of search-oriented labels to reflect that the search can now include the newly displayed subsidiary parent ID