### PR TITLE
Feature/sub 240 implement js accessibility warning

### DIFF
--- a/src/FrontendSchemeRegistration.Application/Options/CookieOptions.cs
+++ b/src/FrontendSchemeRegistration.Application/Options/CookieOptions.cs
@@ -29,4 +29,6 @@ public class CookieOptions
     public int AuthenticationExpiryInMinutes { get; set; }
 
     public string TempDataCookie { get; set; }
+
+    public string JsEnabledCookieName { get; set; }
 }

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Infrastructure/CustomWebApplicationFactory.cs
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Infrastructure/CustomWebApplicationFactory.cs
@@ -1,11 +1,13 @@
 namespace FrontendSchemeRegistration.UI.Component.UnitTests.Infrastructure;
 
 using System.Diagnostics.CodeAnalysis;
+using FrontendSchemeRegistration.Application.Options;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using CookieOptions = FrontendSchemeRegistration.Application.Options.CookieOptions;
 
 [ExcludeFromCodeCoverage]
 public class CustomWebApplicationFactory<TStartup> : WebApplicationFactory<TStartup> where TStartup : class
@@ -19,7 +21,11 @@ public class CustomWebApplicationFactory<TStartup> : WebApplicationFactory<TStar
             configurationBuilder
                 .AddConfiguration(ConfigBuilder.GenerateConfiguration())
                 .AddInMemoryCollection(AdditionalConfig));
-        
-        builder.ConfigureTestServices(ConfigureTestServices);
+
+        builder.ConfigureTestServices(services =>
+        {
+            services.PostConfigure<CookieOptions>(options => options.JsEnabledCookieName = string.Empty);
+            ConfigureTestServices(services);
+        });
     }
 }

--- a/src/FrontendSchemeRegistration.UI.IntegrationTests/TestBase.cs
+++ b/src/FrontendSchemeRegistration.UI.IntegrationTests/TestBase.cs
@@ -2,13 +2,17 @@ namespace FrontendSchemeRegistration.UI.IntegrationTests;
 
 using System.Net.Http;
 using Controllers.FrontendSchemeRegistration;
+using FrontendSchemeRegistration.Application.Options;
 using FrontendSchemeRegistration.MockServer.WebApi;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
+using CookieOptions = FrontendSchemeRegistration.Application.Options.CookieOptions;
 
 public abstract class TestBase
 {
@@ -107,6 +111,11 @@ public abstract class TestBase
                 .Build();
 
             builder.UseConfiguration(testConfig);
+
+            builder.ConfigureTestServices(services =>
+            {
+                services.PostConfigure<CookieOptions>(options => options.JsEnabledCookieName = string.Empty);
+            });
         }
     }
 }

--- a/src/FrontendSchemeRegistration.UI.UnitTests/Controllers/Error/ErrorControllerTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/Controllers/Error/ErrorControllerTests.cs
@@ -42,4 +42,15 @@ public class ErrorControllerTests
         result.Should().BeOfType<ViewResult>()
             .Which.ViewName.Should().Be("ProblemWithSubmissionError");
     }
+
+    [Test]
+    public void JavaScriptRequired_ReturnsJavaScriptRequiredView()
+    {
+        // Act
+        var result = _controller.JavaScriptRequired();
+
+        // Assert
+        result.Should().BeOfType<ViewResult>()
+            .Which.ViewName.Should().Be("JavaScriptRequired");
+    }
 }

--- a/src/FrontendSchemeRegistration.UI.UnitTests/Controllers/Error/ErrorControllerTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/Controllers/Error/ErrorControllerTests.cs
@@ -22,10 +22,10 @@ public class ErrorControllerTests
     }
 
     [Test]
-    public async Task HandleThrownExceptions_ReturnsProblemWithServiceErrorView()
+    public void HandleThrownExceptions_ReturnsProblemWithServiceErrorView()
     {
         // Act
-        var result = await _controller.HandleThrownExceptions();
+        var result = _controller.HandleThrownExceptions();
 
         // Assert
         result.Should().BeOfType<ViewResult>()
@@ -33,10 +33,10 @@ public class ErrorControllerTests
     }
 
     [Test]
-    public async Task HandleThrownSubmissionException_ReturnsProblemWithSubmissionErrorView()
+    public void HandleThrownSubmissionException_ReturnsProblemWithSubmissionErrorView()
     {
         // Act
-        var result = await _controller.HandleThrownSubmissionException();
+        var result = _controller.HandleThrownSubmissionException();
 
         // Assert
         result.Should().BeOfType<ViewResult>()

--- a/src/FrontendSchemeRegistration.UI.UnitTests/Middleware/JavaScriptDetectionMiddlewareTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/Middleware/JavaScriptDetectionMiddlewareTests.cs
@@ -1,0 +1,246 @@
+namespace FrontendSchemeRegistration.UI.UnitTests.Middleware;
+
+using System.Text;
+using Application.Options;
+using Constants;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Moq;
+using UI.Middleware;
+using CookieOptions = Application.Options.CookieOptions;
+
+[TestFixture]
+public class JavaScriptDetectionMiddlewareTests
+{
+    private const string CookieName = ".epr_js_enabled";
+    private const string SignedOutCallbackPath = "/signout/B2C_1A_EPR_SignUpSignIn";
+
+    private Mock<RequestDelegate> _next;
+    private IOptions<CookieOptions> _cookieOptions;
+    private IOptions<AzureAdB2COptions> _b2COptions;
+    private JavaScriptDetectionMiddleware _middleware;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _next = new Mock<RequestDelegate>();
+        _next.Setup(d => d(It.IsAny<HttpContext>())).Returns(Task.CompletedTask);
+
+        _cookieOptions = Options.Create(new CookieOptions { JsEnabledCookieName = CookieName });
+        _b2COptions = Options.Create(new AzureAdB2COptions { SignedOutCallbackPath = SignedOutCallbackPath });
+
+        _middleware = new JavaScriptDetectionMiddleware(_next.Object);
+    }
+
+    [Test]
+    public async Task InvokeAsync_CallsNext_AndDoesNotWriteGatePage_WhenJsCookiePresent()
+    {
+        var context = CreateContext("/some-page");
+        context.Request.Headers.Cookie = $"{CookieName}=1";
+
+        await _middleware.InvokeAsync(context, _cookieOptions, _b2COptions);
+
+        _next.Verify(d => d(context), Times.Once);
+        await AssertResponseIsEmptyAsync(context);
+    }
+
+    [Test]
+    public async Task InvokeAsync_CallsNext_WhenCookieNameIsNull()
+    {
+        var cookieOptions = Options.Create(new CookieOptions { JsEnabledCookieName = null! });
+        var context = CreateContext("/some-page");
+
+        await _middleware.InvokeAsync(context, cookieOptions, _b2COptions);
+
+        _next.Verify(d => d(context), Times.Once);
+        await AssertResponseIsEmptyAsync(context);
+    }
+
+    [Test]
+    public async Task InvokeAsync_CallsNext_WhenCookieNameIsEmpty()
+    {
+        var cookieOptions = Options.Create(new CookieOptions { JsEnabledCookieName = string.Empty });
+        var context = CreateContext("/some-page");
+
+        await _middleware.InvokeAsync(context, cookieOptions, _b2COptions);
+
+        _next.Verify(d => d(context), Times.Once);
+        await AssertResponseIsEmptyAsync(context);
+    }
+
+    [TestCase("/javascript-required")]
+    [TestCase("/error")]
+    [TestCase("/error/something")]
+    [TestCase("/admin/health")]
+    [TestCase("/signin-oidc")]
+    [TestCase("/signout-oidc")]
+    [TestCase("/signout-callback-oidc")]
+    public async Task InvokeAsync_CallsNext_WhenPathIsBypassPath(string path)
+    {
+        var context = CreateContext(path);
+
+        await _middleware.InvokeAsync(context, _cookieOptions, _b2COptions);
+
+        _next.Verify(d => d(context), Times.Once);
+        await AssertResponseIsEmptyAsync(context);
+    }
+
+    [TestCase("/SIGNIN-OIDC")]
+    [TestCase("/Error")]
+    public async Task InvokeAsync_CallsNext_WhenBypassPathMatchIsCaseInsensitive(string path)
+    {
+        var context = CreateContext(path);
+
+        await _middleware.InvokeAsync(context, _cookieOptions, _b2COptions);
+
+        _next.Verify(d => d(context), Times.Once);
+    }
+
+    [Test]
+    public async Task InvokeAsync_CallsNext_WhenPathMatchesConfiguredSignedOutCallbackPath()
+    {
+        var context = CreateContext(SignedOutCallbackPath);
+
+        await _middleware.InvokeAsync(context, _cookieOptions, _b2COptions);
+
+        _next.Verify(d => d(context), Times.Once);
+        await AssertResponseIsEmptyAsync(context);
+    }
+
+    [Test]
+    public async Task InvokeAsync_DoesNotMatchSignedOutCallbackPath_WhenItIsEmpty()
+    {
+        var b2COptions = Options.Create(new AzureAdB2COptions { SignedOutCallbackPath = string.Empty });
+        var context = CreateContext("/some-page");
+
+        await _middleware.InvokeAsync(context, _cookieOptions, b2COptions);
+
+        _next.Verify(d => d(context), Times.Never);
+        (await ReadResponseAsync(context)).Should().Contain("<!DOCTYPE html>");
+    }
+
+    [Test]
+    public async Task InvokeAsync_WritesGatePage_WhenCookieMissingAndPathNotBypassed()
+    {
+        var context = CreateContext("/some-page");
+
+        await _middleware.InvokeAsync(context, _cookieOptions, _b2COptions);
+
+        _next.Verify(d => d(It.IsAny<HttpContext>()), Times.Never);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        context.Response.ContentType.Should().Be("text/html; charset=utf-8");
+        context.Response.Headers.CacheControl.ToString().Should().Be("no-store, no-cache, must-revalidate");
+        context.Response.Headers.Pragma.ToString().Should().Be("no-cache");
+
+        var body = await ReadResponseAsync(context);
+        body.Should().StartWith("<!DOCTYPE html>");
+        body.Should().Contain("<title>Loading…</title>");
+        body.Should().Contain("js-detection-spinner");
+    }
+
+    [Test]
+    public async Task InvokeAsync_GatePage_SetsCookieAttributesIncludingTheCookieName()
+    {
+        var context = CreateContext("/some-page");
+
+        await _middleware.InvokeAsync(context, _cookieOptions, _b2COptions);
+
+        var body = await ReadResponseAsync(context);
+        body.Should().Contain($"{CookieName}=1");
+        body.Should().Contain("path=/");
+        body.Should().Contain("secure");
+        body.Should().Contain("samesite=lax");
+    }
+
+    [Test]
+    public async Task InvokeAsync_GatePage_UsesPathBaseWhenPresent()
+    {
+        var context = CreateContext("/some-page", pathBase: "/report-data");
+
+        await _middleware.InvokeAsync(context, _cookieOptions, _b2COptions);
+
+        var body = await ReadResponseAsync(context);
+        body.Should().Contain("href=\"/report-data/css/application.css\"");
+        body.Should().Contain("url=/report-data/javascript-required");
+        body.Should().Contain("path=/report-data");
+    }
+
+    [Test]
+    public async Task InvokeAsync_GatePage_DefaultsCookiePathToSlashWhenNoPathBase()
+    {
+        var context = CreateContext("/some-page");
+
+        await _middleware.InvokeAsync(context, _cookieOptions, _b2COptions);
+
+        var body = await ReadResponseAsync(context);
+        body.Should().Contain("href=\"/css/application.css\"");
+        body.Should().Contain("url=/javascript-required");
+        body.Should().Contain("path=/;");
+    }
+
+    [Test]
+    public async Task InvokeAsync_GatePage_EmbedsScriptNonceFromHttpContext()
+    {
+        const string nonce = "test-nonce-abc123";
+        var context = CreateContext("/some-page");
+        context.Items[ContextKeys.ScriptNonceKey] = nonce;
+
+        await _middleware.InvokeAsync(context, _cookieOptions, _b2COptions);
+
+        var body = await ReadResponseAsync(context);
+        body.Should().Contain($"<script nonce=\"{nonce}\">");
+    }
+
+    [Test]
+    public async Task InvokeAsync_GatePage_UsesEmptyNonceWhenNoneInHttpContext()
+    {
+        var context = CreateContext("/some-page");
+
+        await _middleware.InvokeAsync(context, _cookieOptions, _b2COptions);
+
+        var body = await ReadResponseAsync(context);
+        body.Should().Contain("<script nonce=\"\">");
+    }
+
+    [Test]
+    public async Task InvokeAsync_GatePage_IncludesNoScriptRedirect()
+    {
+        var context = CreateContext("/some-page");
+
+        await _middleware.InvokeAsync(context, _cookieOptions, _b2COptions);
+
+        var body = await ReadResponseAsync(context);
+        body.Should().Contain("<noscript><meta http-equiv=\"refresh\" content=\"0; url=/javascript-required\"></noscript>");
+    }
+
+    private static DefaultHttpContext CreateContext(string path, string? pathBase = null)
+    {
+        var context = new DefaultHttpContext
+        {
+            Response = { Body = new MemoryStream() },
+            Request =
+            {
+                Path = path
+            }
+        };
+        if (!string.IsNullOrEmpty(pathBase))
+        {
+            context.Request.PathBase = pathBase;
+        }
+        return context;
+    }
+
+    private static async Task<string> ReadResponseAsync(HttpContext context)
+    {
+        context.Response.Body.Position = 0;
+        using var reader = new StreamReader(context.Response.Body, Encoding.UTF8, leaveOpen: true);
+        return await reader.ReadToEndAsync();
+    }
+
+    private static async Task AssertResponseIsEmptyAsync(HttpContext context)
+    {
+        (await ReadResponseAsync(context)).Should().BeEmpty();
+    }
+}

--- a/src/FrontendSchemeRegistration.UI.UnitTests/Services/ResubmissionApplicationServiceTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/Services/ResubmissionApplicationServiceTests.cs
@@ -114,7 +114,7 @@ public class ResubmissionApplicationServiceTests
         _mockSubmissionService = new Mock<ISubmissionService>();
         _mockPaymentCalculationService = new Mock<IPaymentCalculationService>();
         _fixture = new Fixture();
-        _service = new ResubmissionApplicationServices(_mockSessionManager.Object, _mockPaymentCalculationService.Object, _mockSubmissionService.Object, _mockGlobalVariables.Object, _mockFeatureManager.Object, FakeTimeProvider2025);
+        _service = new ResubmissionApplicationServices(_mockSessionManager.Object, _mockPaymentCalculationService.Object, _mockSubmissionService.Object, _mockGlobalVariables.Object, FakeTimeProvider2025);
     }
 
     [Test]

--- a/src/FrontendSchemeRegistration.UI/Controllers/Cookies/CookiesController.cs
+++ b/src/FrontendSchemeRegistration.UI/Controllers/Cookies/CookiesController.cs
@@ -48,6 +48,7 @@ public class CookiesController : Controller
             B2CCookieName = _eprCookieOptions.B2CCookieName,
             CorrelationCookieName = _eprCookieOptions.CorrelationCookieName,
             OpenIdCookieName = _eprCookieOptions.OpenIdCookieName,
+            JsEnabledCookieName = _eprCookieOptions.JsEnabledCookieName,
             CookiesAccepted = hasUserAcceptedCookies,
             ReturnUrl = returnUrlAddress,
             ShowAcknowledgement = cookiesAccepted != null

--- a/src/FrontendSchemeRegistration.UI/Controllers/Error/ErrorController.cs
+++ b/src/FrontendSchemeRegistration.UI/Controllers/Error/ErrorController.cs
@@ -19,4 +19,12 @@ public class ErrorController : Controller
     {
         return View(nameof(ProblemWithSubmissionError));
     }
+
+    [HttpGet]
+    [Route("javascript-required")]
+    [AllowAnonymous]
+    public IActionResult JavaScriptRequired()
+    {
+        return View(nameof(JavaScriptRequired));
+    }
 }

--- a/src/FrontendSchemeRegistration.UI/Controllers/Error/ErrorController.cs
+++ b/src/FrontendSchemeRegistration.UI/Controllers/Error/ErrorController.cs
@@ -9,13 +9,13 @@ public class ErrorController : Controller
 {
     [Route("error")]
     [AllowAnonymous]
-    public async Task<IActionResult> HandleThrownExceptions()
+    public IActionResult HandleThrownExceptions()
     {
         return View(nameof(ProblemWithServiceError), new ErrorViewModel());
     }
 
     [Route("submission-error")]
-    public async Task<IActionResult> HandleThrownSubmissionException()
+    public IActionResult HandleThrownSubmissionException()
     {
         return View(nameof(ProblemWithSubmissionError));
     }

--- a/src/FrontendSchemeRegistration.UI/Extensions/ServiceProviderExtension.cs
+++ b/src/FrontendSchemeRegistration.UI/Extensions/ServiceProviderExtension.cs
@@ -447,6 +447,22 @@ public static class ServiceProviderExtension
                         // provide a couple of hours padding in case of clock change
                         options.RemoteAuthenticationTimeout = remoteAuthTimeout.Value.Add(TimeSpan.FromHours(2));
                     }
+
+                    var existingOnRemoteFailure = options.Events.OnRemoteFailure;
+                    options.Events.OnRemoteFailure = async context =>
+                    {
+                        var message = context.Failure?.Message;
+                        if (message is not null &&
+                            (message.Contains("JavaScript", StringComparison.OrdinalIgnoreCase) ||
+                             message.Contains("AADB2C90157", StringComparison.OrdinalIgnoreCase)))
+                        {
+                            context.HandleResponse();
+                            context.Response.Redirect("/error");
+                            return;
+                        }
+
+                        await existingOnRemoteFailure(context);
+                    };
                 },
                 options =>
                 {

--- a/src/FrontendSchemeRegistration.UI/Middleware/JavaScriptDetectionMiddleware.cs
+++ b/src/FrontendSchemeRegistration.UI/Middleware/JavaScriptDetectionMiddleware.cs
@@ -1,0 +1,118 @@
+namespace FrontendSchemeRegistration.UI.Middleware;
+
+using System.Net;
+using System.Text;
+using Application.Options;
+using Constants;
+using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
+
+public class JavaScriptDetectionMiddleware
+{
+    public const string JavaScriptRequiredPath = "/javascript-required";
+
+    private static readonly string[] BypassPaths =
+    {
+        JavaScriptRequiredPath,
+        "/error",
+        "/admin/health",
+        "/signin-oidc",
+        "/signout-oidc",
+        "/signout-callback-oidc"
+    };
+
+    private readonly RequestDelegate _next;
+
+    public JavaScriptDetectionMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(
+        HttpContext httpContext,
+        IOptions<Application.Options.CookieOptions> cookieOptions,
+        IOptions<AzureAdB2COptions> b2cOptions)
+    {
+        var cookieName = cookieOptions.Value.JsEnabledCookieName;
+
+        if (string.IsNullOrEmpty(cookieName)
+            || httpContext.Request.Cookies.ContainsKey(cookieName)
+            || IsBypassPath(httpContext.Request.Path, b2cOptions.Value.SignedOutCallbackPath))
+        {
+            await _next(httpContext);
+            return;
+        }
+
+        await WriteGatePageAsync(httpContext, cookieName);
+    }
+
+    private static bool IsBypassPath(PathString path, string? signedOutCallbackPath)
+    {
+        foreach (var bypass in BypassPaths)
+        {
+            if (path.StartsWithSegments(bypass, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return !string.IsNullOrEmpty(signedOutCallbackPath)
+            && path.StartsWithSegments(new PathString(signedOutCallbackPath), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static async Task WriteGatePageAsync(HttpContext httpContext, string cookieName)
+    {
+        var nonce = httpContext.Items[ContextKeys.ScriptNonceKey] as string ?? string.Empty;
+        var basePath = httpContext.Request.PathBase.HasValue ? httpContext.Request.PathBase.Value : string.Empty;
+        var cssHref = $"{basePath}/css/application.css";
+        var noScriptUrl = $"{basePath}{JavaScriptRequiredPath}";
+        var cookieAttributes = $"{cookieName}=1; path={(string.IsNullOrEmpty(basePath) ? "/" : basePath)}; secure; samesite=lax";
+
+        var html = new StringBuilder()
+            .Append("<!DOCTYPE html>")
+            .Append("<html lang=\"en\">")
+            .Append("<head>")
+            .Append("<meta charset=\"utf-8\">")
+            .Append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">")
+            .Append("<title>Loading…</title>")
+            .Append($"<link rel=\"stylesheet\" href=\"{WebUtility.HtmlEncode(cssHref)}\">")
+            .Append($"<noscript><meta http-equiv=\"refresh\" content=\"0; url={WebUtility.HtmlEncode(noScriptUrl)}\"></noscript>")
+            .Append($"<script nonce=\"{WebUtility.HtmlEncode(nonce)}\">")
+            .Append("(function(){")
+            .Append("if(!navigator.cookieEnabled){")
+            .Append($"window.location.replace({JsString(noScriptUrl)});return;")
+            .Append("}")
+            .Append($"document.cookie={JsString(cookieAttributes)};")
+            .Append("window.location.replace(window.location.href);")
+            .Append("})();")
+            .Append("</script>")
+            .Append("</head>")
+            .Append("<body>")
+            .Append("<div class=\"js-detection-wrapper\">")
+            .Append("<div class=\"js-detection-spinner\" role=\"status\" aria-live=\"polite\" aria-label=\"Loading\"></div>")
+            .Append("<p class=\"js-detection-label\">Loading…</p>")
+            .Append("</div>")
+            .Append("</body>")
+            .Append("</html>")
+            .ToString();
+
+        httpContext.Response.StatusCode = StatusCodes.Status200OK;
+        httpContext.Response.ContentType = "text/html; charset=utf-8";
+        httpContext.Response.Headers[HeaderNames.CacheControl] = "no-store, no-cache, must-revalidate";
+        httpContext.Response.Headers[HeaderNames.Pragma] = "no-cache";
+
+        await httpContext.Response.WriteAsync(html, Encoding.UTF8);
+    }
+
+    private static string JsString(string value)
+    {
+        var escaped = value
+            .Replace("\\", "\\\\")
+            .Replace("'", "\\'")
+            .Replace("\r", string.Empty)
+            .Replace("\n", string.Empty)
+            .Replace("<", "\\u003C")
+            .Replace(">", "\\u003E");
+        return $"'{escaped}'";
+    }
+}

--- a/src/FrontendSchemeRegistration.UI/Middleware/JavaScriptDetectionMiddleware.cs
+++ b/src/FrontendSchemeRegistration.UI/Middleware/JavaScriptDetectionMiddleware.cs
@@ -48,16 +48,13 @@ public class JavaScriptDetectionMiddleware
 
     private static bool IsBypassPath(PathString path, string? signedOutCallbackPath)
     {
-        foreach (var bypass in BypassPaths)
+        if (BypassPaths.Any(bypass => path.StartsWithSegments(bypass, StringComparison.OrdinalIgnoreCase)))
         {
-            if (path.StartsWithSegments(bypass, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
+            return true;
         }
 
         return !string.IsNullOrEmpty(signedOutCallbackPath)
-            && path.StartsWithSegments(new PathString(signedOutCallbackPath), StringComparison.OrdinalIgnoreCase);
+               && path.StartsWithSegments(new PathString(signedOutCallbackPath), StringComparison.OrdinalIgnoreCase);
     }
 
     private static async Task WriteGatePageAsync(HttpContext httpContext, string cookieName)
@@ -81,7 +78,7 @@ public class JavaScriptDetectionMiddleware
             .Append("(function(){")
             .Append("if(!navigator.cookieEnabled){")
             .Append($"window.location.replace({JsString(noScriptUrl)});return;")
-            .Append("}")
+            .Append('}')
             .Append($"document.cookie={JsString(cookieAttributes)};")
             .Append("window.location.replace(window.location.href);")
             .Append("})();")

--- a/src/FrontendSchemeRegistration.UI/Program.cs
+++ b/src/FrontendSchemeRegistration.UI/Program.cs
@@ -124,6 +124,7 @@ if (!isComponentTest)
     app.UseSerilogRequestLogging(); // after `UseStaticFiles()` to prevent logging of requests to css/js/png etc.
 
 app.UseMiddleware<SecurityHeaderMiddleware>();
+app.UseMiddleware<JavaScriptDetectionMiddleware>();
 app.UseCookiePolicy();
 app.UseStatusCodePagesWithReExecute("/error", "?statusCode={0}");
 app.UseHttpsRedirection();

--- a/src/FrontendSchemeRegistration.UI/Resources/Views/Cookies/Detail.cy.resx
+++ b/src/FrontendSchemeRegistration.UI/Resources/Views/Cookies/Detail.cy.resx
@@ -243,6 +243,12 @@
   <data name="Detail.OpenIdCookiePurpose" xml:space="preserve">
     <value>Fel rhan o’r broses o greu cyfrif a mewngofnodi, mae’r cwci nons yn cael ei ddefnyddio gan OpenIDConnect Microsoft i liniaru ymosodiadau ailchwarae (lle mae haciwr yn rhyng-gipio neges ac yn ailchwarae honno i’r derbynnydd arfaethedig).</value>
   </data>
+  <data name="Detail.JsEnabledCookiePurpose" xml:space="preserve">
+    <value>Yn cadarnhau bod JavaScript wedi’i alluogi yn eich porwr fel y gall y gwasanaeth lwytho’r tudalennau mewngofnodi.</value>
+  </data>
+  <data name="Detail.JsEnabledCookieExpires" xml:space="preserve">
+    <value>30 diwrnod</value>
+  </data>
   <data name="Details.Title" xml:space="preserve">
     <value>Cwcis</value>
   </data>

--- a/src/FrontendSchemeRegistration.UI/Resources/Views/Cookies/Detail.cy.resx
+++ b/src/FrontendSchemeRegistration.UI/Resources/Views/Cookies/Detail.cy.resx
@@ -247,7 +247,7 @@
     <value>Yn cadarnhau bod JavaScript wedi’i alluogi yn eich porwr fel y gall y gwasanaeth lwytho’r tudalennau mewngofnodi.</value>
   </data>
   <data name="Detail.JsEnabledCookieExpires" xml:space="preserve">
-    <value>30 diwrnod</value>
+    <value>Pan fyddwch yn cau eich porwr</value>
   </data>
   <data name="Details.Title" xml:space="preserve">
     <value>Cwcis</value>

--- a/src/FrontendSchemeRegistration.UI/Resources/Views/Cookies/Detail.en.resx
+++ b/src/FrontendSchemeRegistration.UI/Resources/Views/Cookies/Detail.en.resx
@@ -247,7 +247,7 @@
     <value>Confirms that your browser has JavaScript enabled so the service can load the sign-in pages.</value>
   </data>
   <data name="Detail.JsEnabledCookieExpires" xml:space="preserve">
-    <value>30 days</value>
+    <value>When you close your browser</value>
   </data>
   <data name="Details.Title" xml:space="preserve">
     <value>Cookies</value>

--- a/src/FrontendSchemeRegistration.UI/Resources/Views/Cookies/Detail.en.resx
+++ b/src/FrontendSchemeRegistration.UI/Resources/Views/Cookies/Detail.en.resx
@@ -243,6 +243,12 @@
   <data name="Detail.OpenIdCookiePurpose" xml:space="preserve">
     <value>As part of the create account and log in process, the nonce cookie is used by Microsoft's OpenIDConnect to mitigate replay attacks (where a hacker intercepts a message and replays it to the intended receiver).</value>
   </data>
+  <data name="Detail.JsEnabledCookiePurpose" xml:space="preserve">
+    <value>Confirms that your browser has JavaScript enabled so the service can load the sign-in pages.</value>
+  </data>
+  <data name="Detail.JsEnabledCookieExpires" xml:space="preserve">
+    <value>30 days</value>
+  </data>
   <data name="Details.Title" xml:space="preserve">
     <value>Cookies</value>
   </data>

--- a/src/FrontendSchemeRegistration.UI/Services/ResubmissionApplicationServices.cs
+++ b/src/FrontendSchemeRegistration.UI/Services/ResubmissionApplicationServices.cs
@@ -23,7 +23,6 @@ public class ResubmissionApplicationServices(
     IPaymentCalculationService paymentCalculationService,
     ISubmissionService submissionService,
     IOptions<GlobalVariables> globalVariables,
-    IFeatureManager featureManager,
     TimeProvider timeProvider) : IResubmissionApplicationService
 {
     public async Task<string> CreatePomResubmissionReferenceNumberForProducer(FrontendSchemeRegistrationSession session, SubmissionPeriod submissionPeriod, string organisationNumber, string submittedByName, Guid submissionId, int? historyCount)

--- a/src/FrontendSchemeRegistration.UI/ViewModels/CookieDetailViewModel.cs
+++ b/src/FrontendSchemeRegistration.UI/ViewModels/CookieDetailViewModel.cs
@@ -27,6 +27,8 @@ public class CookieDetailViewModel
 
     public string OpenIdCookieName { get; set; }
 
+    public string JsEnabledCookieName { get; set; }
+
     public string GoogleAnalyticsDefaultCookieName { get; set; }
 
     public string GoogleAnalyticsAdditionalCookieName { get; set; }

--- a/src/FrontendSchemeRegistration.UI/Views/Cookies/Detail.cshtml
+++ b/src/FrontendSchemeRegistration.UI/Views/Cookies/Detail.cshtml
@@ -94,6 +94,11 @@
                             <td class="govuk-table__cell">@Localizer["Detail.OpenIdCookiePurpose"]</td>
                             <td class="govuk-table__cell">@Localizer["Detail.OpenIdCookieExpires"]</td>
                         </tr>
+                        <tr class="govuk-table__row">
+                            <th scope="row" class="govuk-table__header">@Model.JsEnabledCookieName</th>
+                            <td class="govuk-table__cell">@Localizer["Detail.JsEnabledCookiePurpose"]</td>
+                            <td class="govuk-table__cell">@Localizer["Detail.JsEnabledCookieExpires"]</td>
+                        </tr>
                     </tbody>
                 </table>
                 

--- a/src/FrontendSchemeRegistration.UI/Views/Error/JavaScriptRequired.cshtml
+++ b/src/FrontendSchemeRegistration.UI/Views/Error/JavaScriptRequired.cshtml
@@ -1,5 +1,5 @@
 @{
-    ViewData["Title"] = Localizer["javascript_required_title"];
+    ViewData["Title"] = "You need to enable JavaScript / Mae angen i chi alluogi JavaScript";
     Layout = "_LayoutNoJs";
 }
 

--- a/src/FrontendSchemeRegistration.UI/Views/Error/JavaScriptRequired.cshtml
+++ b/src/FrontendSchemeRegistration.UI/Views/Error/JavaScriptRequired.cshtml
@@ -1,0 +1,19 @@
+@{
+    ViewData["Title"] = Localizer["javascript_required_title"];
+    Layout = "_LayoutNoJs";
+}
+
+<main class="govuk-main-wrapper govuk-!-padding-top-4" id="javascript-required-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds govuk-!-margin-top-8">
+            <h1 class="govuk-heading-l">You need to enable JavaScript</h1>
+            <p class="govuk-body">This service needs JavaScript to work properly. Your browser does not allow it at the moment. If you’re unable to do this, you can contact the helpdesk.</p>
+            <br />
+            <h1 class="govuk-heading-l">Mae angen i chi alluogi JavaScript</h1>
+            <p class="govuk-body">Mae angen JavaScript ar y gwasanaeth hwn i weithio'n iawn. Nid yw eich porwr yn caniatáu hynny ar hyn o bryd. Os na allwch wneud hyn, gallwch cysylltwch â'r ddesg gymorth.</p>
+            <br />
+            <p class="govuk-body govuk-!-margin-bottom-2">Telephone: / Ffon: 0300 060 0002</p>
+            <p class="govuk-body">Email: / Ebost: <a class="govuk-link govuk-link--no-visited-state" href="mailto:eprcustomerservice@defra.gov.uk">eprcustomerservice@defra.gov.uk</a></p>
+        </div>
+    </div>
+</main>

--- a/src/FrontendSchemeRegistration.UI/Views/Shared/_Layout.cshtml
+++ b/src/FrontendSchemeRegistration.UI/Views/Shared/_Layout.cshtml
@@ -10,7 +10,8 @@
     var dockerImageString = "not_set";
     if (!string.IsNullOrWhiteSpace(dockerImage))
     {
-        dockerImageString = dockerImage.Split(":").Last();
+        var parts = dockerImage.Split(":");
+        dockerImageString = parts[^1];
     }
 }
 

--- a/src/FrontendSchemeRegistration.UI/Views/Shared/_LayoutNoJs.cshtml
+++ b/src/FrontendSchemeRegistration.UI/Views/Shared/_LayoutNoJs.cshtml
@@ -7,7 +7,8 @@
     var dockerImageString = "not_set";
     if (!string.IsNullOrWhiteSpace(dockerImage))
     {
-        dockerImageString = dockerImage.Split(":").Last();
+        var parts = dockerImage.Split(":");
+        dockerImageString = parts[^1];
     }
 }
 

--- a/src/FrontendSchemeRegistration.UI/Views/Shared/_LayoutNoJs.cshtml
+++ b/src/FrontendSchemeRegistration.UI/Views/Shared/_LayoutNoJs.cshtml
@@ -1,0 +1,55 @@
+@using System.Reflection
+
+@inject IOptions<ExternalUrlOptions> ExternalUrlOptions;
+
+@{
+    var dockerImage = Environment.GetEnvironmentVariable("DOCKER_CUSTOM_IMAGE_NAME");
+    var dockerImageString = "not_set";
+    if (!string.IsNullOrWhiteSpace(dockerImage))
+    {
+        dockerImageString = dockerImage.Split(":").Last();
+    }
+}
+
+<!DOCTYPE html>
+<html lang="en" class="govuk-template">
+    <head>
+        <meta charset="utf-8">
+        <title>@ViewData["Title"] - @SharedLocalizer["application_title"] - GOV.UK</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+        <meta name="theme-color" content="#0b0c0c">
+
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="application-name" content="Report Packaging Data" data-version="@Assembly.GetExecutingAssembly().GetName().Version.ToString()">
+        <meta name="govuk:app-image-name" content="@dockerImageString">
+        <meta name="govuk:app-image-build-number" content="@Environment.GetEnvironmentVariable("BUILD_NUMBER")">
+        <meta name="govuk:app-image-git-sha" content="@Environment.GetEnvironmentVariable("GIT_SHA")">
+
+        <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/images/favicon.ico" type="image/x-icon">
+        <link rel="mask-icon" href="/images/govuk-mask-icon.svg" color="#0b0c0c">
+        <link rel="apple-touch-icon" sizes="180x180" href="/images/govuk-apple-touch-icon-180x180.png">
+        <link rel="apple-touch-icon" sizes="167x167" href="/images/govuk-apple-touch-icon-167x167.png">
+        <link rel="apple-touch-icon" sizes="152x152" href="/images/govuk-apple-touch-icon-152x152.png">
+        <link rel="apple-touch-icon" href="/images/govuk-apple-touch-icon.png">
+        <link rel="stylesheet" href="~/css/application.css">
+    </head>
+    <body class="govuk-template__body">
+        <a id="main-content" href="#main-content" class="govuk-skip-link">@SharedLocalizer["skip_to_main_content_text"]</a>
+
+        @await Html.PartialAsync("Partials/Govuk/_Header", ExternalUrlOptions.Value)
+
+        <div class="govuk-width-container">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    @await Component.InvokeAsync("PhaseBanner")
+                </div>
+            </div>
+        </div>
+
+        <div class="govuk-width-container">
+            @RenderBody()
+        </div>
+
+        @await Html.PartialAsync("Partials/Govuk/_Footer")
+    </body>
+</html>

--- a/src/FrontendSchemeRegistration.UI/appsettings.json
+++ b/src/FrontendSchemeRegistration.UI/appsettings.json
@@ -31,6 +31,7 @@
     "B2CCookieName": "x-ms-cpim-*",
     "CorrelationCookieName": ".epr_correlation",
     "OpenIdCookieName": ".epr_openid_nonce",
+    "JsEnabledCookieName": ".epr_js_enabled",
     "CookiePolicyDurationInMonths": 12
   },
   "EmailAddresses": {

--- a/src/FrontendSchemeRegistration.UI/assets/scss/application.scss
+++ b/src/FrontendSchemeRegistration.UI/assets/scss/application.scss
@@ -11,6 +11,7 @@ $govuk-assets-path: '/report-data/';
 @import './components/card';
 @import './components/buttons';
 @import './components/tabs';
+@import './components/javascript-detection';
 
 $narrow-media-width: 40.0625em;
 

--- a/src/FrontendSchemeRegistration.UI/assets/scss/components/_javascript-detection.scss
+++ b/src/FrontendSchemeRegistration.UI/assets/scss/components/_javascript-detection.scss
@@ -1,0 +1,35 @@
+.js-detection-wrapper {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: govuk-spacing(4);
+    text-align: center;
+}
+
+.js-detection-spinner {
+    width: 48px;
+    height: 48px;
+    border: 6px solid govuk-colour("mid-grey");
+    border-top-color: govuk-colour("blue");
+    border-radius: 50%;
+    animation: js-detection-spin 1s linear infinite;
+    margin-bottom: govuk-spacing(3);
+}
+
+.js-detection-label {
+    @include govuk-font($size: 19);
+    margin: 0;
+}
+
+@keyframes js-detection-spin {
+    to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .js-detection-spinner {
+        animation: none;
+        border-top-color: govuk-colour("mid-grey");
+    }
+}


### PR DESCRIPTION
Detects whether the browser has JavaScript enabled before allowing the OIDC challenge to fire, since B2C's sign-in pages require JavaScript and otherwise show an unhelpful "we can't sign you in" fallback.

- JavaScriptDetectionMiddleware writes a gate page on the first request that sets a session cookie via an inline script and reloads. Subsequent requests in the same session pass through. The OIDC and signed-out callback paths are bypassed so they never get intercepted.
- A <noscript> meta-refresh on the gate page redirects users without JS to /javascript-required, served via a new minimal _LayoutNoJs layout that excludes analytics, cookie banner, session timeout warning and GOV.UK Frontend JS init.
- Chain OnRemoteFailure on the OIDC events so the new handler for JavaScript-related B2C errors doesn't overwrite Microsoft.Identity.Web's default handling of password reset, user cancel etc.
- Add .epr_js_enabled cookie name to CookieOptions and appsettings.