### PR TITLE
Feature/sub 295 upgrade dotnet10

### DIFF
--- a/pipelines/ci_pipeline.yaml
+++ b/pipelines/ci_pipeline.yaml
@@ -22,7 +22,7 @@ parameters:
     default: true
 
 
-pool: DEFRA-COMMON-ubuntu2004-SSV3
+pool: DEFRA-COMMON-UBUNTU-SSV3
 
 variables:
   - template: vars/DEV4-development.yaml
@@ -41,7 +41,7 @@ variables:
   - name: runNugetTasks
     value: true
   - name: dotnetVersion
-    value: dotnetVersion8
+    value: dotnetVersion10
 
 resources:
   repositories:

--- a/pipelines/deployment-pipeline.yaml
+++ b/pipelines/deployment-pipeline.yaml
@@ -1,6 +1,6 @@
 trigger: none
 pr: none
-pool: DEFRA-COMMON-ubuntu2204-SSV3
+pool: DEFRA-COMMON-UBUNTU-SSV3
 appendCommitMessageToRunName: false
 name: 'Deploy code to $(serviceName)'
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <CodeAnalysisRuleSet>..\stylecop.ruleset</CodeAnalysisRuleSet>
         <!-- SonarCloud does not recognise file-scoped namespaces in current version. -->

--- a/src/FrontendSchemeRegistration.Application.UnitTests/FrontendSchemeRegistration.Application.UnitTests.csproj
+++ b/src/FrontendSchemeRegistration.Application.UnitTests/FrontendSchemeRegistration.Application.UnitTests.csproj
@@ -11,7 +11,7 @@
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="ILogger.Moq" Version="1.1.10" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
         <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="NUnit" Version="4.1.0" />
@@ -20,10 +20,8 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Net.Http.Headers" Version="8.0.7" />
+        <PackageReference Include="Microsoft.Net.Http.Headers" Version="10.0.9" />
         <PackageReference Include="PactNet" Version="4.5.0" />
-        <PackageReference Include="System.Text.Json" Version="8.0.6" />
-        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/FrontendSchemeRegistration.Application/FrontendSchemeRegistration.Application.csproj
+++ b/src/FrontendSchemeRegistration.Application/FrontendSchemeRegistration.Application.csproj
@@ -10,21 +10,20 @@
         <PackageReference Include="CsvHelper" Version="33.0.1" />
         <PackageReference Include="EPR.Common.Authorization" Version="1.0.22" />
         <PackageReference Include="libphonenumber-csharp" Version="8.13.42" />
-        <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="10.0.9" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.9" />
         <PackageReference Include="Microsoft.FeatureManagement" Version="3.5.0" />
         <PackageReference Include="Microsoft.Identity.Client" Version="4.62.0" />
         <PackageReference Include="Microsoft.Identity.Web" Version="3.0.1" />
         <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.0.1" />
-        <PackageReference Include="Microsoft.Net.Http.Headers" Version="8.0.7" />
+        <PackageReference Include="Microsoft.Net.Http.Headers" Version="10.0.9" />
         <PackageReference Include="StackExchange.Redis" Version="2.8.24" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
-        <PackageReference Include="System.Text.Json" Version="8.0.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/FrontendSchemeRegistration.MockServer/FrontendSchemeRegistration.MockServer.csproj
+++ b/src/FrontendSchemeRegistration.MockServer/FrontendSchemeRegistration.MockServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SonarQubeExclude>true</SonarQubeExclude>

--- a/src/FrontendSchemeRegistration.PactTests/FrontendSchemeRegistration.PactTests.csproj
+++ b/src/FrontendSchemeRegistration.PactTests/FrontendSchemeRegistration.PactTests.csproj
@@ -2,7 +2,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
         <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="NUnit" Version="4.1.0" />
@@ -12,7 +12,6 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="PactNet" Version="4.5.0" />
-        <PackageReference Include="System.Text.Json" Version="8.0.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Features/LandingPage.feature.cs
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Features/LandingPage.feature.cs
@@ -27,7 +27,7 @@ namespace FrontendSchemeRegistration.UI.Component.UnitTests.Features
         
         private static string[] featureTags = ((string[])(null));
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features", "Landing Page", "As a user\nI want to see the landing page        ", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features", "Landing Page", "As a user\r\nI want to see the landing page        ", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
 #line 1 "LandingPage.feature"
 #line hidden

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/FrontendSchemeRegistration.UI.Component.UnitTests.csproj
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/FrontendSchemeRegistration.UI.Component.UnitTests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <SonarQubeExclude>true</SonarQubeExclude>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.23" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
         <PackageReference Include="Reqnroll" Version="3.3.2" />
         <PackageReference Include="Reqnroll.NUnit" Version="3.3.2" />

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Infrastructure/Verify.cs
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Infrastructure/Verify.cs
@@ -23,9 +23,23 @@ public static class VerifyHtml
             // any script output currently.
             foreach (var node in nodes.QuerySelectorAll("script"))
                 node.Remove();
-            
+
             foreach (var node in nodes.QuerySelectorAll("input[name=\"__RequestVerificationToken\"]"))
                 node.Attributes.GetNamedItem("value").Value = "[Scrubbed]";
+
+            // Razor's CSS-isolation scope-id (b-XXXXXXXXXX) hash is OS-sensitive
+            // in net10 — Windows and Linux produce different hashes for the same
+            // component, breaking snapshots across platforms. Strip the attribute
+            // so snapshots compare on content only.
+            foreach (var element in nodes.QuerySelectorAll("*"))
+            {
+                var scopeAttrs = element.Attributes
+                    .Where(a => a.Name.StartsWith("b-", StringComparison.Ordinal))
+                    .Select(a => a.Name)
+                    .ToList();
+                foreach (var name in scopeAttrs)
+                    element.RemoveAttribute(name);
+            }
         });
     }
     

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenBasicUser_ShouldHidePrivilegedContent_path=-report-data-home-compliance-scheme.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenBasicUser_ShouldHidePrivilegedContent_path=-report-data-home-compliance-scheme.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fhome-compliance-scheme">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenBasicUser_ShouldHidePrivilegedContent_path=-report-data-home-compliance-scheme.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenBasicUser_ShouldHidePrivilegedContent_path=-report-data-home-compliance-scheme.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fhome-compliance-scheme">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenBasicUser_ShouldHidePrivilegedContent_path=-report-data-home-compliance-scheme.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenBasicUser_ShouldHidePrivilegedContent_path=-report-data-home-compliance-scheme.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Home - Report packaging data - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fhome-compliance-scheme">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenBasicUser_ShouldHidePrivilegedContent_path=-report-data-manage-your-recycling-obligations.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenBasicUser_ShouldHidePrivilegedContent_path=-report-data-manage-your-recycling-obligations.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Manage your 2026 recycling obligations - Report packaging data - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fmanage-your-recycling-obligations">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenBasicUser_ShouldHidePrivilegedContent_path=-report-data-manage-your-recycling-obligations.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenBasicUser_ShouldHidePrivilegedContent_path=-report-data-manage-your-recycling-obligations.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fmanage-your-recycling-obligations">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
@@ -271,7 +271,8 @@
         <div class="govuk-card govuk-!-margin-bottom-6">
           <div class="govuk-card-body">
             <h2 class="govuk-heading-m">Submit your certificate of compliance</h2>
-            <p class="govuk-body">An approved or delegated person must submit your 2026 certificate of compliance before or on
+            <p class="govuk-body">
+              An approved or delegated person must submit your 2026 certificate of compliance before or on
               <strong>31 January 2027</strong>
             </p>
           </div>

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenBasicUser_ShouldHidePrivilegedContent_path=-report-data-manage-your-recycling-obligations.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenBasicUser_ShouldHidePrivilegedContent_path=-report-data-manage-your-recycling-obligations.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fmanage-your-recycling-obligations">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
@@ -271,8 +271,7 @@
         <div class="govuk-card govuk-!-margin-bottom-6">
           <div class="govuk-card-body">
             <h2 class="govuk-heading-m">Submit your certificate of compliance</h2>
-            <p class="govuk-body">
-              An approved or delegated person must submit your 2026 certificate of compliance before or on
+            <p class="govuk-body">An approved or delegated person must submit your 2026 certificate of compliance before or on
               <strong>31 January 2027</strong>
             </p>
           </div>

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=cy_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=cy_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fhome-compliance-scheme">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=cy_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=cy_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Hafan - Rhoi gwybod am ddata pecynwaith - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fhome-compliance-scheme">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=cy_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=cy_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fhome-compliance-scheme">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=cy_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=cy_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fhome-compliance-scheme">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=cy_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=cy_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Hafan - Rhoi gwybod am ddata pecynwaith - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fhome-compliance-scheme">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=cy_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=cy_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fhome-compliance-scheme">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=en_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=en_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fhome-compliance-scheme">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=en_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=en_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fhome-compliance-scheme">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=en_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=en_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Home - Report packaging data - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fhome-compliance-scheme">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=en_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=en_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fhome-compliance-scheme">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=en_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=en_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fhome-compliance-scheme">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=en_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=en_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Home - Report packaging data - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fhome-compliance-scheme">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=en_csocEnabled=True_serviceRole=DelegatedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=en_csocEnabled=True_serviceRole=DelegatedPerson.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fhome-compliance-scheme">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=en_csocEnabled=True_serviceRole=DelegatedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=en_csocEnabled=True_serviceRole=DelegatedPerson.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fhome-compliance-scheme">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=en_csocEnabled=True_serviceRole=DelegatedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-home-compliance-scheme_language=en_csocEnabled=True_serviceRole=DelegatedPerson.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Home - Report packaging data - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fhome-compliance-scheme">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=cy_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=cy_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fmanage-your-recycling-obligations">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=cy_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=cy_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fmanage-your-recycling-obligations">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=cy_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=cy_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Rheoli'ch rhwymedigaethau ailgylchu ar gyfer 2026 - Rhoi gwybod am ddata pecynwaith - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fmanage-your-recycling-obligations">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=cy_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=cy_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fmanage-your-recycling-obligations">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=cy_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=cy_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fmanage-your-recycling-obligations">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=cy_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=cy_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Rheoli'ch rhwymedigaethau ailgylchu ar gyfer 2026 - Rhoi gwybod am ddata pecynwaith - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fmanage-your-recycling-obligations">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=en_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=en_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Manage your 2026 recycling obligations - Report packaging data - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fmanage-your-recycling-obligations">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=en_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=en_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fmanage-your-recycling-obligations">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=en_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=en_csocEnabled=False_serviceRole=ApprovedPerson.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fmanage-your-recycling-obligations">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=en_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=en_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Manage your 2026 recycling obligations - Report packaging data - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fmanage-your-recycling-obligations">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=en_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=en_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fmanage-your-recycling-obligations">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=en_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=en_csocEnabled=True_serviceRole=ApprovedPerson.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fmanage-your-recycling-obligations">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=en_csocEnabled=True_serviceRole=DelegatedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=en_csocEnabled=True_serviceRole=DelegatedPerson.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Manage your 2026 recycling obligations - Report packaging data - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fmanage-your-recycling-obligations">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=en_csocEnabled=True_serviceRole=DelegatedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=en_csocEnabled=True_serviceRole=DelegatedPerson.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fmanage-your-recycling-obligations">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=en_csocEnabled=True_serviceRole=DelegatedPerson.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenCsocEnabledOrDisabled_ShouldLocalizeAsExpected_path=-report-data-manage-your-recycling-obligations_language=en_csocEnabled=True_serviceRole=DelegatedPerson.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fmanage-your-recycling-obligations">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenNoObligationData_ShouldHideSubmissionTile.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenNoObligationData_ShouldHideSubmissionTile.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Manage your 2026 recycling obligations - Report packaging data - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fmanage-your-recycling-obligations">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenNoObligationData_ShouldHideSubmissionTile.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenNoObligationData_ShouldHideSubmissionTile.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fmanage-your-recycling-obligations">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenNoObligationData_ShouldHideSubmissionTile.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/CsocTests.WhenNoObligationData_ShouldHideSubmissionTile.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fmanage-your-recycling-obligations">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-bulk_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-bulk_language=cy.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccept-bulk">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-bulk_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-bulk_language=cy.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Derbyn neu wrthod PRNs a PERNs - Rhoi gwybod am ddata pecynwaith - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccept-bulk">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-bulk_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-bulk_language=cy.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccept-bulk">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-bulk_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-bulk_language=en.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccept-bulk">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-bulk_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-bulk_language=en.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccept-bulk">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-bulk_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-bulk_language=en.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Accept or reject PRNs and PERNs - Report packaging data - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccept-bulk">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000001_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000001_language=cy.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccept-prn%2F00000000-0000-0000-0000-000000000001">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000001_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000001_language=cy.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccept-prn%2F00000000-0000-0000-0000-000000000001">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000001_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000001_language=cy.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Derbyn y PRN yma - Rhoi gwybod am ddata pecynwaith - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccept-prn%2F00000000-0000-0000-0000-000000000001">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000001_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000001_language=en.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccept-prn%2F00000000-0000-0000-0000-000000000001">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000001_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000001_language=en.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccept-prn%2F00000000-0000-0000-0000-000000000001">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000001_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000001_language=en.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Accept this PRN - Report packaging data - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccept-prn%2F00000000-0000-0000-0000-000000000001">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000003_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000003_language=cy.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccept-prn%2F00000000-0000-0000-0000-000000000003">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000003_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000003_language=cy.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccept-prn%2F00000000-0000-0000-0000-000000000003">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000003_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000003_language=cy.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Derbyn y PRN yma - Rhoi gwybod am ddata pecynwaith - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccept-prn%2F00000000-0000-0000-0000-000000000003">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000003_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000003_language=en.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccept-prn%2F00000000-0000-0000-0000-000000000003">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000003_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000003_language=en.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Accept this PRN - Report packaging data - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccept-prn%2F00000000-0000-0000-0000-000000000003">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000003_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accept-prn-00000000-0000-0000-0000-000000000003_language=en.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccept-prn%2F00000000-0000-0000-0000-000000000003">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prn-00000000-0000-0000-0000-000000000005_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prn-00000000-0000-0000-0000-000000000005_language=cy.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccepted-prn%2F00000000-0000-0000-0000-000000000005">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prn-00000000-0000-0000-0000-000000000005_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prn-00000000-0000-0000-0000-000000000005_language=cy.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccepted-prn%2F00000000-0000-0000-0000-000000000005">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prn-00000000-0000-0000-0000-000000000005_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prn-00000000-0000-0000-0000-000000000005_language=cy.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>EPR ar gyfer data pecynnu: rheoli eich rhwymedigaeth ailgylchu - Rhoi gwybod am ddata pecynwaith - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccepted-prn%2F00000000-0000-0000-0000-000000000005">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prn-00000000-0000-0000-0000-000000000005_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prn-00000000-0000-0000-0000-000000000005_language=en.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccepted-prn%2F00000000-0000-0000-0000-000000000005">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prn-00000000-0000-0000-0000-000000000005_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prn-00000000-0000-0000-0000-000000000005_language=en.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>EPR for packaging data: manage your recycling obligation - Report packaging data - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccepted-prn%2F00000000-0000-0000-0000-000000000005">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prn-00000000-0000-0000-0000-000000000005_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prn-00000000-0000-0000-0000-000000000005_language=en.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccepted-prn%2F00000000-0000-0000-0000-000000000005">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prns_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prns_language=cy.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccepted-prns">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" aria-label="main" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prns_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prns_language=cy.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Data yr EPR dros becynwaith: rheoli'ch rhwymedigaeth ailgylchu - Rhoi gwybod am ddata pecynwaith - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccepted-prns">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" aria-label="main" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prns_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prns_language=cy.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccepted-prns">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" aria-label="main" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prns_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prns_language=en.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccepted-prns">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" aria-label="main" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prns_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prns_language=en.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>EPR for packaging data: manage your recycling obligation - Report packaging data - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccepted-prns">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" aria-label="main" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prns_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-accepted-prns_language=en.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Faccepted-prns">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -34,7 +34,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" aria-label="main" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000001_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000001_language=cy.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Derbyn y PRN yma - Rhoi gwybod am ddata pecynwaith - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fselected-prn%2F00000000-0000-0000-0000-000000000001">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000001_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000001_language=cy.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fselected-prn%2F00000000-0000-0000-0000-000000000001">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000001_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000001_language=cy.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fselected-prn%2F00000000-0000-0000-0000-000000000001">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000001_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000001_language=en.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Accept this PRN - Report packaging data - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fselected-prn%2F00000000-0000-0000-0000-000000000001">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000001_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000001_language=en.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fselected-prn%2F00000000-0000-0000-0000-000000000001">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000001_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000001_language=en.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fselected-prn%2F00000000-0000-0000-0000-000000000001">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000002_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000002_language=cy.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fselected-prn%2F00000000-0000-0000-0000-000000000002">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000002_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000002_language=cy.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fselected-prn%2F00000000-0000-0000-0000-000000000002">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000002_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000002_language=cy.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Derbyn y PRN yma - Rhoi gwybod am ddata pecynwaith - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fselected-prn%2F00000000-0000-0000-0000-000000000002">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000002_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000002_language=en.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fselected-prn%2F00000000-0000-0000-0000-000000000002">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000002_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000002_language=en.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fselected-prn%2F00000000-0000-0000-0000-000000000002">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000002_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-selected-prn-00000000-0000-0000-0000-000000000002_language=en.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Accept this PRN - Report packaging data - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fselected-prn%2F00000000-0000-0000-0000-000000000002">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance-alt_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance-alt_language=cy.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Derbyn neu wrthod PRNs a PERNs - Rhoi gwybod am ddata pecynwaith - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fview-awaiting-acceptance-alt">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="select-multiple-prns">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance-alt_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance-alt_language=cy.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fview-awaiting-acceptance-alt">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="select-multiple-prns">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance-alt_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance-alt_language=cy.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fview-awaiting-acceptance-alt">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="select-multiple-prns">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance-alt_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance-alt_language=en.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fview-awaiting-acceptance-alt">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="select-multiple-prns">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance-alt_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance-alt_language=en.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Accept or reject PRNs and PERNs - Report packaging data - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fview-awaiting-acceptance-alt">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="select-multiple-prns">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance-alt_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance-alt_language=en.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fview-awaiting-acceptance-alt">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="select-multiple-prns">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance_language=cy.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fview-awaiting-acceptance">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance_language=cy.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fview-awaiting-acceptance">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance_language=cy.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance_language=cy.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Chwilio PRNs a PERNs - Rhoi gwybod am ddata pecynwaith - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fview-awaiting-acceptance">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Neidio i’r prif gynnwys</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance_language=en.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fview-awaiting-acceptance">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-kvf76et9mx="" class="govuk-width-container">
-  <div b-kvf76et9mx="" class="govuk-grid-row">
-    <div b-kvf76et9mx="" class="govuk-grid-column-full">
+<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-a7jj0nrtu1="" class="govuk-width-container">
+  <div b-a7jj0nrtu1="" class="govuk-grid-row">
+    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-kvf76et9mx="" class="govuk-width-container">
+<div b-a7jj0nrtu1="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance_language=en.verified.html
@@ -4,10 +4,10 @@
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fview-awaiting-acceptance">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a b-kvf76et9mx="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div b-kvf76et9mx="" class="govuk-width-container">
+  <div b-kvf76et9mx="" class="govuk-grid-row">
+    <div b-kvf76et9mx="" class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div b-kvf76et9mx="" class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance_language=en.verified.html
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/ObligationsTests.WhenPrnsArePresent_ShouldLocalizeAsExpected_path=-report-data-view-awaiting-acceptance_language=en.verified.html
@@ -1,13 +1,13 @@
-﻿
+
 <title>Search PRNs and PERNs - Report packaging data - GOV.UK</title>
 
 <form method="POST" action="/report-data/update-cookie-acceptance?returnUrl=%2Freport-data%2Fview-awaiting-acceptance">
   <input name="__RequestVerificationToken" type="hidden" value="[Scrubbed]">
 </form>
-<a b-a7jj0nrtu1="" id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
-  <div b-a7jj0nrtu1="" class="govuk-grid-row">
-    <div b-a7jj0nrtu1="" class="govuk-grid-column-full">
+<a id="main-content" href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -37,7 +37,7 @@
     </div>
   </div>
 </div>
-<div b-a7jj0nrtu1="" class="govuk-width-container">
+<div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/FrontendSchemeRegistration.UI.IntegrationTests/FrontendSchemeRegistration.UI.IntegrationTests.csproj
+++ b/src/FrontendSchemeRegistration.UI.IntegrationTests/FrontendSchemeRegistration.UI.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="7.2.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.23" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
         <PackageReference Include="NUnit" Version="4.1.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />

--- a/src/FrontendSchemeRegistration.UI.UnitTests/FrontendSchemeRegistration.UI.UnitTests.csproj
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/FrontendSchemeRegistration.UI.UnitTests.csproj
@@ -8,8 +8,8 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="ILogger.Moq" Version="1.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NUnit" Version="4.1.0" />
@@ -19,8 +19,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="PactNet" Version="4.5.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.6" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FrontendSchemeRegistration.UI/Dockerfile
+++ b/src/FrontendSchemeRegistration.UI/Dockerfile
@@ -1,4 +1,4 @@
-FROM defradigital/dotnetcore-development:dotnet8.0 AS base
+FROM defradigital/dotnetcore-development:dotnet10.0 AS base
 USER root
  
 # Expose the app on a defined port, configurable via a build argument
@@ -6,7 +6,7 @@ ARG PORT=3000
 ENV ASPNETCORE_URLS=http://*:${PORT}
 EXPOSE ${PORT}
 
-FROM defradigital/dotnetcore-development:dotnet8.0 AS build
+FROM defradigital/dotnetcore-development:dotnet10.0 AS build
 USER root
 WORKDIR /src
 COPY ["FrontendSchemeRegistration.UI/FrontendSchemeRegistration.UI.csproj", "FrontendSchemeRegistration.UI/"]
@@ -39,7 +39,7 @@ RUN dotnet publish "FrontendSchemeRegistration.UI.csproj" -c Release -o /app/pub
 RUN dotnet publish -c Release -o out
 
 # Build runtime image
-FROM defradigital/dotnetcore:dotnet8.0
+FROM defradigital/dotnetcore:dotnet10.0
 COPY --from=build-env /home/dotnet/FrontendSchemeRegistration.UI/out .
 
 # Install tzdata

--- a/src/FrontendSchemeRegistration.UI/FrontendSchemeRegistration.UI.csproj
+++ b/src/FrontendSchemeRegistration.UI/FrontendSchemeRegistration.UI.csproj
@@ -111,18 +111,16 @@
     <ItemGroup>
         <PackageReference Include="CsvHelper" Version="33.0.1" />
         <PackageReference Include="MagicMapper" Version="14.0.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.8.0" />
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.1.0" />
         <PackageReference Include="Microsoft.FeatureManagement" Version="3.5.0" />
         <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.5.0" />
         <PackageReference Include="Microsoft.Graph" Version="5.91.0" />
         <PackageReference Include="Microsoft.Identity.Web.TokenAcquisition" Version="3.1.0" />
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.6.1" />
         <PackageReference Include="PactNet" Version="4.5.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.7" />
-        <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="8.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.9" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
         <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
@@ -130,10 +128,8 @@
         <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />
         <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.1.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-        <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-        <PackageReference Include="System.Drawing.Common" Version="8.0.7" />
-        <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
-        <PackageReference Include="System.Text.Json" Version="8.0.6" />
+        <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
+        <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.9" />
     </ItemGroup>
     <ItemGroup>
         <EmbeddedResource Update="Resources\CompanyDetailsSubmissionErrorCodes.cy.resx">

--- a/src/FrontendSchemeRegistration.UI/FrontendSchemeRegistration.UI.csproj
+++ b/src/FrontendSchemeRegistration.UI/FrontendSchemeRegistration.UI.csproj
@@ -115,6 +115,7 @@
         <PackageReference Include="Microsoft.FeatureManagement" Version="3.5.0" />
         <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.5.0" />
         <PackageReference Include="Microsoft.Graph" Version="5.91.0" />
+        <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.22.2" />
         <PackageReference Include="Microsoft.Identity.Web.TokenAcquisition" Version="3.1.0" />
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.6.1" />
         <PackageReference Include="PactNet" Version="4.5.0" />


### PR DESCRIPTION
SUB-295: Upgrade to .NET 10

- Bump TargetFramework from net8.0 to net10.0 (Directory.Build.props and the three projects that override it).
- Update runtime-aligned Microsoft.* / System.* packages to 10.0.9 (AspNetCore.*, Extensions.*, EntityFrameworkCore, Net.Http.Headers, Drawing.Common, Security.Cryptography.Pkcs, Mvc.Testing). 
- TimeProvider.Testing pinned to 10.1.0 (only stable on net10).
- Remove redundant PackageReferences now in the shared framework (NU1510)
- Update Dockerfile base images from dotnet8.0 to dotnet10.0.
- Update CI pipeline dotnetVersion variable to dotnetVersion10.
- Switch the build and deployment pipelines to the new build agents that support the .NET10 SDK
- Pin Microsoft.Kiota.Abstractions to 1.22.2 to override the vulnerable 1.71.1 transitive dependency from Microsoft.Graph 5.91.0 (NU1903)
- Razor's CSS-isolation scope-id (b-XXXXXXXXXX attribute) hash is OS-sensitive in .net10 — Windows produces e.g. b-kvf76et9mx while Linux CI produces b-a7jj0nrtu1 for the same component. This made Component snapshots valid on only one platform at a time. These changes make the Component tests work in Windows and Linux.