### PR TITLE
feat(search PRN): Add december waste flash

### DIFF
--- a/src/FrontendSchemeRegistration.UI/Resources/Views/Prns/SearchPrns.en.resx
+++ b/src/FrontendSchemeRegistration.UI/Resources/Views/Prns/SearchPrns.en.resx
@@ -104,4 +104,10 @@
 	<data name="page_title" xml:space="preserve">
 		<value>Search PRNs and PERNs</value>
 	</data>
+	<data name="acceptance_year" xml:space="preserve">
+    	<value>Can be accepted towards {0}.</value>
+  	</data>
+	<data name="acceptance_years" xml:space="preserve">
+    	<value>Can be accepted towards {0} or {1}.</value>
+  	</data>
 </root>

--- a/src/FrontendSchemeRegistration.UI/Resources/Views/Prns/SearchPrns.en.resx
+++ b/src/FrontendSchemeRegistration.UI/Resources/Views/Prns/SearchPrns.en.resx
@@ -105,9 +105,9 @@
 		<value>Search PRNs and PERNs</value>
 	</data>
 	<data name="acceptance_year" xml:space="preserve">
-    	<value>Can be accepted towards {0}.</value>
+    	<value>Can be accepted towards {0}</value>
   	</data>
 	<data name="acceptance_years" xml:space="preserve">
-    	<value>Can be accepted towards {0} or {1}.</value>
+    	<value>Can be accepted towards {0} or {1}</value>
   	</data>
 </root>

--- a/src/FrontendSchemeRegistration.UI/ViewModels/Prns/BasePrnViewModel.cs
+++ b/src/FrontendSchemeRegistration.UI/ViewModels/Prns/BasePrnViewModel.cs
@@ -45,6 +45,8 @@ namespace FrontendSchemeRegistration.UI.ViewModels.Prns
 
         public string NoteType { get; set; }
 
+        public bool IsAwaitingAcceptance => ApprovalStatus == PrnStatus.AwaitingAcceptance;
+
         public string ApprovalStatusDisplayCssColour => ApprovalStatus switch
         {
 	        PrnStatus.AwaitingAcceptance => "grey",

--- a/src/FrontendSchemeRegistration.UI/Views/Prns/SearchPrns.cshtml
+++ b/src/FrontendSchemeRegistration.UI/Views/Prns/SearchPrns.cshtml
@@ -7,6 +7,14 @@
 	ViewData["Title"] = Localizer["search_prns_and_perns"];
 	var scriptNonce = (string?)Context.Items[ContextKeys.ScriptNonceKey];
 	var errorsViewModel = new ErrorsViewModel(ViewData.ModelState.ToErrorDictionary(), Localizer);
+	
+	Func<bool, string>? rowBorder = (bool IsAwaitingAcceptance) => IsAwaitingAcceptance ? "border-bottom-0" : null;
+	Func<int[], string> DecemberWasteFlashText = (int[] AvailableAcceptanceYears) => AvailableAcceptanceYears.Length switch {
+		1 => string.Format(Localizer["acceptance_year"].Value, AvailableAcceptanceYears[0]),
+		2 => string.Format(Localizer["acceptance_years"].Value, AvailableAcceptanceYears[0], AvailableAcceptanceYears[1]),
+		_ => string.Empty
+	};
+
 }
 <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content">
 	<div class="govuk-grid-row">
@@ -105,7 +113,7 @@
 					@foreach (var prn in Model.ActivePageOfResults)
 					{
 						<tbody class="govuk-table__body">
-							<tr class="govuk-table__row">
+							<tr class="govuk-table__row @rowBorder(prn.IsAwaitingAcceptance)">
 								<td class="govuk-table__cell">
 									<a class="govuk-link" href="@Url.Action(nameof(PrnsController.SelectSinglePrn), "Prns", new { id = prn.ExternalId })" aria-label="@Localizer["prn_or_pern_number"] @prn.PrnOrPernNumber">
 										@prn.PrnOrPernNumber
@@ -125,6 +133,14 @@
 									</div>
 								</td>
 							</tr>
+							
+							@if (prn.IsAwaitingAcceptance && prn.IsDecemberWaste) {
+							<tr class="govuk-table__row">
+								<td class="govuk-table__cell" colspan="7">
+									@await Html.PartialAsync("../Shared/Partials/Prns/_prnFlashLabel", new ViewDataDictionary(ViewData) { { "BackgroundColor", "blue" }, { "LabelText", @DecemberWasteFlashText(prn.AvailableAcceptanceYears) } })
+								</td>
+							</tr>
+							}
 						</tbody>
 					}
 				}

--- a/src/FrontendSchemeRegistration.UI/Views/Prns/SearchPrns.cshtml
+++ b/src/FrontendSchemeRegistration.UI/Views/Prns/SearchPrns.cshtml
@@ -104,7 +104,8 @@
 				{
 					@foreach (var prn in Model.ActivePageOfResults)
 					{
-						var rowBorder = prn.IsAwaitingAcceptance && prn.IsDecemberWaste ? "border-bottom-0" : null;
+						var showDecemberWasteFlash = prn.IsAwaitingAcceptance && prn.IsDecemberWaste;
+						var rowBorder = showDecemberWasteFlash ? "border-bottom-0" : null;
 						var decemberWasteFlashText =  prn.AvailableAcceptanceYears.Length switch {
 							1 => string.Format(Localizer["acceptance_year"].Value, prn.AvailableAcceptanceYears[0]),
 							2 => string.Format(Localizer["acceptance_years"].Value, prn.AvailableAcceptanceYears[0], prn.AvailableAcceptanceYears[1]),
@@ -133,7 +134,7 @@
 								</td>
 							</tr>
 							
-							@if (prn.IsAwaitingAcceptance && prn.IsDecemberWaste) {
+							@if (showDecemberWasteFlash) {
 							<tr class="govuk-table__row">
 								<td class="govuk-table__cell" colspan="7">
 									@await Html.PartialAsync("../Shared/Partials/Prns/_prnFlashLabel", new ViewDataDictionary(ViewData) { { "BackgroundColor", "blue" }, { "LabelText", @decemberWasteFlashText } })

--- a/src/FrontendSchemeRegistration.UI/Views/Prns/SearchPrns.cshtml
+++ b/src/FrontendSchemeRegistration.UI/Views/Prns/SearchPrns.cshtml
@@ -104,7 +104,7 @@
 				{
 					@foreach (var prn in Model.ActivePageOfResults)
 					{
-						var rowBorder = prn.IsAwaitingAcceptance ? "border-bottom-0" : null;
+						var rowBorder = prn.IsAwaitingAcceptance && prn.IsDecemberWaste ? "border-bottom-0" : null;
 						var DecemberWasteFlashText =  prn.AvailableAcceptanceYears.Length switch {
 							1 => string.Format(Localizer["acceptance_year"].Value, prn.AvailableAcceptanceYears[0]),
 							2 => string.Format(Localizer["acceptance_years"].Value, prn.AvailableAcceptanceYears[0], prn.AvailableAcceptanceYears[1]),

--- a/src/FrontendSchemeRegistration.UI/Views/Prns/SearchPrns.cshtml
+++ b/src/FrontendSchemeRegistration.UI/Views/Prns/SearchPrns.cshtml
@@ -7,14 +7,6 @@
 	ViewData["Title"] = Localizer["search_prns_and_perns"];
 	var scriptNonce = (string?)Context.Items[ContextKeys.ScriptNonceKey];
 	var errorsViewModel = new ErrorsViewModel(ViewData.ModelState.ToErrorDictionary(), Localizer);
-	
-	Func<bool, string>? rowBorder = (bool IsAwaitingAcceptance) => IsAwaitingAcceptance ? "border-bottom-0" : null;
-	Func<int[], string> DecemberWasteFlashText = (int[] AvailableAcceptanceYears) => AvailableAcceptanceYears.Length switch {
-		1 => string.Format(Localizer["acceptance_year"].Value, AvailableAcceptanceYears[0]),
-		2 => string.Format(Localizer["acceptance_years"].Value, AvailableAcceptanceYears[0], AvailableAcceptanceYears[1]),
-		_ => string.Empty
-	};
-
 }
 <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content">
 	<div class="govuk-grid-row">
@@ -112,8 +104,15 @@
 				{
 					@foreach (var prn in Model.ActivePageOfResults)
 					{
+						var rowBorder = prn.IsAwaitingAcceptance ? "border-bottom-0" : null;
+						var DecemberWasteFlashText =  prn.AvailableAcceptanceYears.Length switch {
+							1 => string.Format(Localizer["acceptance_year"].Value, prn.AvailableAcceptanceYears[0]),
+							2 => string.Format(Localizer["acceptance_years"].Value, prn.AvailableAcceptanceYears[0], prn.AvailableAcceptanceYears[1]),
+							_ => string.Empty
+						};
+
 						<tbody class="govuk-table__body">
-							<tr class="govuk-table__row @rowBorder(prn.IsAwaitingAcceptance)">
+							<tr class="govuk-table__row @rowBorder">
 								<td class="govuk-table__cell">
 									<a class="govuk-link" href="@Url.Action(nameof(PrnsController.SelectSinglePrn), "Prns", new { id = prn.ExternalId })" aria-label="@Localizer["prn_or_pern_number"] @prn.PrnOrPernNumber">
 										@prn.PrnOrPernNumber
@@ -137,7 +136,7 @@
 							@if (prn.IsAwaitingAcceptance && prn.IsDecemberWaste) {
 							<tr class="govuk-table__row">
 								<td class="govuk-table__cell" colspan="7">
-									@await Html.PartialAsync("../Shared/Partials/Prns/_prnFlashLabel", new ViewDataDictionary(ViewData) { { "BackgroundColor", "blue" }, { "LabelText", @DecemberWasteFlashText(prn.AvailableAcceptanceYears) } })
+									@await Html.PartialAsync("../Shared/Partials/Prns/_prnFlashLabel", new ViewDataDictionary(ViewData) { { "BackgroundColor", "blue" }, { "LabelText", @DecemberWasteFlashText } })
 								</td>
 							</tr>
 							}

--- a/src/FrontendSchemeRegistration.UI/Views/Prns/SearchPrns.cshtml
+++ b/src/FrontendSchemeRegistration.UI/Views/Prns/SearchPrns.cshtml
@@ -105,7 +105,7 @@
 					@foreach (var prn in Model.ActivePageOfResults)
 					{
 						var rowBorder = prn.IsAwaitingAcceptance && prn.IsDecemberWaste ? "border-bottom-0" : null;
-						var DecemberWasteFlashText =  prn.AvailableAcceptanceYears.Length switch {
+						var decemberWasteFlashText =  prn.AvailableAcceptanceYears.Length switch {
 							1 => string.Format(Localizer["acceptance_year"].Value, prn.AvailableAcceptanceYears[0]),
 							2 => string.Format(Localizer["acceptance_years"].Value, prn.AvailableAcceptanceYears[0], prn.AvailableAcceptanceYears[1]),
 							_ => string.Empty
@@ -136,7 +136,7 @@
 							@if (prn.IsAwaitingAcceptance && prn.IsDecemberWaste) {
 							<tr class="govuk-table__row">
 								<td class="govuk-table__cell" colspan="7">
-									@await Html.PartialAsync("../Shared/Partials/Prns/_prnFlashLabel", new ViewDataDictionary(ViewData) { { "BackgroundColor", "blue" }, { "LabelText", @DecemberWasteFlashText } })
+									@await Html.PartialAsync("../Shared/Partials/Prns/_prnFlashLabel", new ViewDataDictionary(ViewData) { { "BackgroundColor", "blue" }, { "LabelText", @decemberWasteFlashText } })
 								</td>
 							</tr>
 							}

--- a/src/FrontendSchemeRegistration.UI/Views/Prns/SearchPrns.cshtml
+++ b/src/FrontendSchemeRegistration.UI/Views/Prns/SearchPrns.cshtml
@@ -105,7 +105,7 @@
 					@foreach (var prn in Model.ActivePageOfResults)
 					{
 						var showDecemberWasteFlash = prn.IsAwaitingAcceptance && prn.IsDecemberWaste;
-						var rowBorder = showDecemberWasteFlash ? "border-bottom-0" : null;
+						var borderBottomOff = showDecemberWasteFlash ? "border-bottom-0" : null;
 						var decemberWasteFlashText =  prn.AvailableAcceptanceYears.Length switch {
 							1 => string.Format(Localizer["acceptance_year"].Value, prn.AvailableAcceptanceYears[0]),
 							2 => string.Format(Localizer["acceptance_years"].Value, prn.AvailableAcceptanceYears[0], prn.AvailableAcceptanceYears[1]),
@@ -113,19 +113,19 @@
 						};
 
 						<tbody class="govuk-table__body">
-							<tr class="govuk-table__row @rowBorder">
-								<td class="govuk-table__cell">
+							<tr class="govuk-table__row @borderBottomOff">
+								<td class="govuk-table__cell @borderBottomOff">
 									<a class="govuk-link" href="@Url.Action(nameof(PrnsController.SelectSinglePrn), "Prns", new { id = prn.ExternalId })" aria-label="@Localizer["prn_or_pern_number"] @prn.PrnOrPernNumber">
 										@prn.PrnOrPernNumber
 										<span class="govuk-visually-hidden">@Localizer["prn_or_pern_number"]</span>
 									</a>
 								</td>
-								<td class="govuk-table__cell" data-label=@Localizer["material"]>@PrnDataResourcesLocalizer.Material(prn)</td>
-								<td class="govuk-table__cell" data-label=@Localizer["date_issued"]>@prn.DateIssuedDisplay</td>
-								<td class="govuk-table__cell" data-label=@Localizer["december_waste"]>@SharedLocalizer[prn.DecemberWasteDisplay]</td>
-								<td class="govuk-table__cell" data-label=@Localizer["issued_by"]>@prn.IssuedBy</td>
-								<td class="govuk-table__cell govuk-table__cell--numeric" data-label=@Localizer["tonnage"]>@prn.Tonnage</td>
-								<td class="govuk-table__cell">
+								<td class="govuk-table__cell @borderBottomOff" data-label=@Localizer["material"]>@PrnDataResourcesLocalizer.Material(prn)</td>
+								<td class="govuk-table__cell @borderBottomOff" data-label=@Localizer["date_issued"]>@prn.DateIssuedDisplay</td>
+								<td class="govuk-table__cell @borderBottomOff" data-label=@Localizer["december_waste"]>@SharedLocalizer[prn.DecemberWasteDisplay]</td>
+								<td class="govuk-table__cell @borderBottomOff" data-label=@Localizer["issued_by"]>@prn.IssuedBy</td>
+								<td class="govuk-table__cell govuk-table__cell--numeric @borderBottomOff" data-label=@Localizer["tonnage"]>@prn.Tonnage</td>
+								<td class="govuk-table__cell @borderBottomOff">
 									<div class="govuk-table__cell--numeric">
 										<span class="govuk-tag govuk-tag--@prn.ApprovalStatusDisplayCssColour">
 											@PrnDataLocalizer[prn.ApprovalStatus]

--- a/src/FrontendSchemeRegistration.UI/Views/Shared/Partials/Prns/_prnFlashLabel.cshtml
+++ b/src/FrontendSchemeRegistration.UI/Views/Shared/Partials/Prns/_prnFlashLabel.cshtml
@@ -1,0 +1,16 @@
+@using FrontendSchemeRegistration.Application.Constants
+@using FrontendSchemeRegistration.UI.ViewModels.Prns
+@model PrnSearchResultViewModel;
+@inject IStringLocalizer<PrnDataResources> PrnDataLocalizer
+
+@{
+    var BackgroundColor = ViewData["BackgroundColor"]?.ToString() ?? "grey";
+    var LabelText = ViewData["LabelText"].ToString();
+}
+
+<span class="govuk-tag govuk-tag--@BackgroundColor text-align-left">
+    @LabelText
+</span>
+
+ 
+

--- a/src/FrontendSchemeRegistration.UI/Views/Shared/Partials/Prns/_prnFlashLabel.cshtml
+++ b/src/FrontendSchemeRegistration.UI/Views/Shared/Partials/Prns/_prnFlashLabel.cshtml
@@ -1,6 +1,6 @@
 @using FrontendSchemeRegistration.Application.Constants
 @using FrontendSchemeRegistration.UI.ViewModels.Prns
-@model PrnSearchResultViewModel;
+@model PrnSearchResultListViewModel;
 @inject IStringLocalizer<PrnDataResources> PrnDataLocalizer
 
 @{
@@ -8,7 +8,7 @@
     var LabelText = ViewData["LabelText"].ToString();
 }
 
-<span class="govuk-tag govuk-tag--@BackgroundColor text-align-left">
+<span class="flash-container flash-container--@BackgroundColor">
     @LabelText
 </span>
 

--- a/src/FrontendSchemeRegistration.UI/assets/scss/abstracts/_utilities.scss
+++ b/src/FrontendSchemeRegistration.UI/assets/scss/abstracts/_utilities.scss
@@ -14,3 +14,7 @@
   word-break: break-word;
   overflow-wrap: break-word;
 }
+
+.text-align-left {
+  text-align: left;
+}

--- a/src/FrontendSchemeRegistration.UI/assets/scss/abstracts/_utilities.scss
+++ b/src/FrontendSchemeRegistration.UI/assets/scss/abstracts/_utilities.scss
@@ -14,7 +14,3 @@
   word-break: break-word;
   overflow-wrap: break-word;
 }
-
-.text-align-left {
-  text-align: left;
-}

--- a/src/FrontendSchemeRegistration.UI/assets/scss/application.scss
+++ b/src/FrontendSchemeRegistration.UI/assets/scss/application.scss
@@ -1,464 +1,472 @@
-$govuk-assets-path: '/report-data/';
-@import 'node_modules/govuk-frontend/govuk/all';
+$govuk-assets-path: "/report-data/";
+@import "node_modules/govuk-frontend/govuk/all";
 
 // Abstracts
-@import './abstracts/utilities';
+@import "./abstracts/utilities";
 
 // Components
-@import './components/language-toggle';
-@import './components/account-navbar';
-@import './components/notification-banner';
-@import './components/card';
-@import './components/buttons';
-@import './components/tabs';
-@import './components/javascript-detection';
+@import "./components/language-toggle";
+@import "./components/account-navbar";
+@import "./components/notification-banner";
+@import "./components/card";
+@import "./components/buttons";
+@import "./components/tabs";
+@import "./components/javascript-detection";
+@import "./components/flash";
 
 $narrow-media-width: 40.0625em;
 
 .two-card-row {
-    @media (min-width: $narrow-media-width) {
-        display: flex;
-        gap: 15px;
+  @media (min-width: $narrow-media-width) {
+    display: flex;
+    gap: 15px;
 
-        .card-item:last-child {
-            margin-left: 15px;
-            margin-right: -15px;
-        }
+    .card-item:last-child {
+      margin-left: 15px;
+      margin-right: -15px;
     }
+  }
 
-    .card-item {
-        margin-bottom: 30px;
-    }
+  .card-item {
+    margin-bottom: 30px;
+  }
 
-    margin: 0;
+  margin: 0;
 }
 
 #compliance-scheme-tabs {
-    margin-bottom: 0;
+  margin-bottom: 0;
 
-    .govuk-tabs__panel {
-        border-left: 0;
-        border-right: 0;
-        border-bottom: 0;
-        padding-left: 0;
+  .govuk-tabs__panel {
+    border-left: 0;
+    border-right: 0;
+    border-bottom: 0;
+    padding-left: 0;
 
-        .scheme-name {
-            color: #505a5f;
-            font-weight: normal;
-            margin: 0;
-        }
-
-        .govuk-inset-text {
-            div {
-                padding-bottom: 5px;
-            }
-
-            .last-updated-date,
-            .members-info {
-                color: #505a5f;
-            }
-
-            .members-info {
-                width: 66.67%;
-                padding-top: 16px;
-            }
-
-            a {
-                display: block;
-                padding-top: 8px;
-            }
-        }
+    .scheme-name {
+      color: #505a5f;
+      font-weight: normal;
+      margin: 0;
     }
+
+    .govuk-inset-text {
+      div {
+        padding-bottom: 5px;
+      }
+
+      .last-updated-date,
+      .members-info {
+        color: #505a5f;
+      }
+
+      .members-info {
+        width: 66.67%;
+        padding-top: 16px;
+      }
+
+      a {
+        display: block;
+        padding-top: 8px;
+      }
+    }
+  }
 }
 
 .epr-header.epr-header--with-additional-navigation {
-    .epr-auth-nav {
-        float: right;
-    }
+  .epr-auth-nav {
+    float: right;
+  }
 
-    .epr-auth-nav__link {
-        color: #fff;
-        font-weight: 700;
-        line-height: 1.8em;
-        text-decoration: none;
-
-        &:hover {
-            text-decoration: underline;
-        }
-
-        &:focus {
-            color: #0b0c0c;
-        }
-    }
-}
-
-.epr-header__service-name {
-    float: left;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    display: inline-block;
-    font-family: GDS Transport, arial, sans-serif;
-    font-size: 18px;
-    font-size: 1.125rem;
+  .epr-auth-nav__link {
+    color: #fff;
     font-weight: 700;
-    line-height: 1.11111;
-    margin-bottom: 10px;
-}
-
-.epr-header__service-name--linked {
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    font-family: GDS Transport, arial, sans-serif;
+    line-height: 1.8em;
     text-decoration: none;
 
-    &:link {
-        color: #fff;
-    }
-
-    &:visited {
-        color: #fff;
-    }
-
-    &:active {
-        color: hsla(0, 0%, 100%, .99);
-    }
-
     &:hover {
-        color: hsla(0, 0%, 100%, .99);
-        text-decoration: underline;
-        text-decoration-thickness: 3px;
-        text-underline-offset: .1em;
+      text-decoration: underline;
     }
 
     &:focus {
-        background-color: #fd0;
-        box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
-        color: #0b0c0c;
-        outline: 3px solid transparent;
-        text-decoration: none;
+      color: #0b0c0c;
     }
+  }
+}
+
+.epr-header__service-name {
+  float: left;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  display: inline-block;
+  font-family:
+    GDS Transport,
+    arial,
+    sans-serif;
+  font-size: 18px;
+  font-size: 1.125rem;
+  font-weight: 700;
+  line-height: 1.11111;
+  margin-bottom: 10px;
+}
+
+.epr-header__service-name--linked {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-family:
+    GDS Transport,
+    arial,
+    sans-serif;
+  text-decoration: none;
+
+  &:link {
+    color: #fff;
+  }
+
+  &:visited {
+    color: #fff;
+  }
+
+  &:active {
+    color: hsla(0, 0%, 100%, 0.99);
+  }
+
+  &:hover {
+    color: hsla(0, 0%, 100%, 0.99);
+    text-decoration: underline;
+    text-decoration-thickness: 3px;
+    text-underline-offset: 0.1em;
+  }
+
+  &:focus {
+    background-color: #fd0;
+    box-shadow:
+      0 -2px #fd0,
+      0 4px #0b0c0c;
+    color: #0b0c0c;
+    outline: 3px solid transparent;
+    text-decoration: none;
+  }
 }
 
 @media print {
-    .epr-header__service-name {
-        font-family: sans-serif;
-        font-size: 18pt;
-        line-height: 1.15;
-    }
+  .epr-header__service-name {
+    font-family: sans-serif;
+    font-size: 18pt;
+    line-height: 1.15;
+  }
 
-    .epr-header__service-name--linked {
-        font-family: sans-serif;
-    }
+  .epr-header__service-name--linked {
+    font-family: sans-serif;
+  }
 }
 
 @media (min-width: $narrow-media-width) {
-    .epr-header__service-name {
-        font-size: 24px;
-        font-size: 1.5rem;
-        line-height: 1.25;
-    }
+  .epr-header__service-name {
+    font-size: 24px;
+    font-size: 1.5rem;
+    line-height: 1.25;
+  }
 }
 
 .no-blue-border-under-header {
-    border-bottom: 10px solid transparent;
+  border-bottom: 10px solid transparent;
 }
 
 table.cookies-table {
-    @media (min-width: $narrow-media-width) {
-        table-layout: auto;
+  @media (min-width: $narrow-media-width) {
+    table-layout: auto;
+  }
+
+  @media (max-width: $narrow-media-width) {
+    table-layout: fixed;
+
+    th,
+    td {
+      word-wrap: break-word;
     }
 
-    @media (max-width: $narrow-media-width) {
-        table-layout: fixed;
-
-        th,
-        td {
-            word-wrap: break-word;
-        }
-
-        th:first-child {
-            width: 33%;
-        }
-
-        th:last-child {
-            width: 15%;
-        }
+    th:first-child {
+      width: 33%;
     }
+
+    th:last-child {
+      width: 15%;
+    }
+  }
 }
 
 .remove-member-link {
-    @media (min-width: 40.0625em) {
-        font-size: 1.1875rem;
-        padding: 0;
-    }
+  @media (min-width: 40.0625em) {
+    font-size: 1.1875rem;
+    padding: 0;
+  }
 
-    padding: 10px 0 10px 0;
-    margin-bottom: 22px;
+  padding: 10px 0 10px 0;
+  margin-bottom: 22px;
 
-    a {
-        &:link,
-        &:visited,
-        &:hover,
-        &:active,
-        &:focus {
-            color: govuk-colour("red");
-        }
+  a {
+    &:link,
+    &:visited,
+    &:hover,
+    &:active,
+    &:focus {
+      color: govuk-colour("red");
     }
+  }
 }
 
 .details-file-upload-form h1 {
-    margin: 0;
+  margin: 0;
 }
 
 .overflow-x-auto {
-    overflow-x: auto;
+  overflow-x: auto;
 }
 
 .deadline-placeholder {
-    @media (min-width: 40.0625em) {
-        height: round(calc(19px * 1.3157894737));
-    }
+  @media (min-width: 40.0625em) {
+    height: round(calc(19px * 1.3157894737));
+  }
 
-    height: calc(16px * 1.25);
-    margin-bottom: 20px;
+  height: calc(16px * 1.25);
+  margin-bottom: 20px;
 }
 
 .blank-line-before {
-    margin-top: 1em;
+  margin-top: 1em;
 }
 
 .href-text--red {
-    color: govuk-colour("red");
+  color: govuk-colour("red");
 }
 
 .prn-sort-filter-clear {
-    @media (min-width: $narrow-media-width) {
-        justify-content: right;
-        flex-direction: row;
-        gap: 5px;
-    }
+  @media (min-width: $narrow-media-width) {
+    justify-content: right;
+    flex-direction: row;
+    gap: 5px;
+  }
 
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: left;
-    flex-direction: column;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: left;
+  flex-direction: column;
 }
 
-.prn-pdf-logo{
-    height:30px;
+.prn-pdf-logo {
+  height: 30px;
 }
 
 .prn-logos-container {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    justify-content: space-evenly;
-    align-items: center;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: space-evenly;
+  align-items: center;
 
-    .prn-logos-items {
-        flex: 0 0 25%;
-        margin-bottom: 20px;
-    }
+  .prn-logos-items {
+    flex: 0 0 25%;
+    margin-bottom: 20px;
+  }
 }
 
 .prn-responsive-table {
-    width: 100%;
-    border-collapse: collapse;
+  width: 100%;
+  border-collapse: collapse;
 
-    .govuk-table__header th, td {
-        padding: 8px;
+  .govuk-table__header th,
+  td {
+    padding: 8px;
+  }
+
+  th {
+    background-color: #ffffff;
+  }
+
+  .govuk-table__row:hover {
+    background-color: #f1f1f1;
+  }
+
+  @media screen and (max-width: $narrow-media-width) {
+    thead {
+      display: none;
+      width: 100%;
     }
 
-    th {
-        background-color: #ffffff;
+    tr {
+      display: block;
+      margin-bottom: 10px;
+      border-bottom: 2px solid #ccc; /* Add this line for the border */
     }
 
-    .govuk-table__row:hover {
-        background-color: #f1f1f1;
+    td {
+      display: block;
+      text-align: left;
+      border: none;
+      position: relative;
+      padding-left: 50%;
     }
 
-    @media screen and (max-width: $narrow-media-width) {
-        thead {
-            display: none;
-            width: 100%;
-        }
-
-        tr {
-            display: block;
-            margin-bottom: 10px;
-            border-bottom: 2px solid #ccc; /* Add this line for the border */
-        }
-
-        td {
-            display: block;
-            text-align: left;
-            border: none;
-            position: relative;
-            padding-left: 50%;
-        }
-
-        th:first-child {
-            width: 33%;
-        }
-
-        th:last-child {
-            width: 15%;
-        }
-
-        td::before {
-            content: attr(data-label);
-            position: absolute;
-            left: 0;
-            width: 50%;
-            padding-left: 10px;
-            font-weight: bold;
-            text-align: left;
-        }
-
-        .govuk-checkboxes__input {
-            margin-right: 10px;
-        }
-
-        .govuk-checkboxes__label {
-            display: flex;
-            align-items: center;
-        }
+    th:first-child {
+      width: 33%;
     }
 
-    .no-visited-highlight:visited {
-        color: inherit;
+    th:last-child {
+      width: 15%;
     }
+
+    td::before {
+      content: attr(data-label);
+      position: absolute;
+      left: 0;
+      width: 50%;
+      padding-left: 10px;
+      font-weight: bold;
+      text-align: left;
+    }
+
+    .govuk-checkboxes__input {
+      margin-right: 10px;
+    }
+
+    .govuk-checkboxes__label {
+      display: flex;
+      align-items: center;
+    }
+  }
+
+  .no-visited-highlight:visited {
+    color: inherit;
+  }
 }
 
 .no-wrap-text {
-    white-space: nowrap;
+  white-space: nowrap;
 }
 
 .prn-obligation-responsive-table {
-    width: 100%;
-    border-collapse: collapse;
+  width: 100%;
+  border-collapse: collapse;
 
-    .header,
-    .govuk-table__cell {
-        text-align: left;
+  .header,
+  .govuk-table__cell {
+    text-align: left;
+  }
+
+  .govuk-table__header--numeric,
+  .govuk-table__cell--numeric {
+    text-align: right;
+  }
+
+  .govuk-table__head th:first-child {
+    width: 15%;
+  }
+
+  .govuk-table__head th:last-child {
+    width: 13%;
+  }
+
+  @media screen and (max-width: $narrow-media-width) {
+    .govuk-table__head {
+      display: none;
     }
 
-    .govuk-table__header--numeric,
+    .govuk-table__row {
+      display: block;
+      margin-bottom: 10px;
+    }
+
+    .govuk-table__cell,
+    .govuk-table__header {
+      display: flex;
+      justify-content: space-between;
+      padding: 10px;
+      position: relative;
+    }
+
+    .govuk-table__cell::before {
+      content: attr(data-header);
+      font-weight: bold;
+      display: inline-block;
+      margin-right: 10px;
+      width: 50%;
+    }
+
     .govuk-table__cell--numeric {
-        text-align: right;
+      text-align: left;
     }
 
-    .govuk-table__head th:first-child {
-        width: 15%;
+    .govuk-table__cell {
+      display: flex;
+      justify-content: space-between;
     }
-
-    .govuk-table__head th:last-child {
-        width: 13%;
-    }
-
-    @media screen and (max-width: $narrow-media-width) {
-        .govuk-table__head {
-            display: none;
-        }
-
-        .govuk-table__row {
-            display: block;
-            margin-bottom: 10px;
-        }
-
-        .govuk-table__cell,
-        .govuk-table__header {
-            display: flex;
-            justify-content: space-between;
-            padding: 10px;
-            position: relative;
-        }
-
-        .govuk-table__cell::before {
-            content: attr(data-header);
-            font-weight: bold;
-            display: inline-block;
-            margin-right: 10px;
-            width: 50%;
-        }
-
-        .govuk-table__cell--numeric {
-            text-align: left;
-        }
-
-        .govuk-table__cell {
-            display: flex;
-            justify-content: space-between;
-        }
-    }
+  }
 }
 
 .no-bottom-margin {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 .box-container {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
 }
 
 .box {
-    box-sizing: border-box;
-    display: grid;
-    width: 100%;
+  box-sizing: border-box;
+  display: grid;
+  width: 100%;
 }
 
 .spinner-overlay {
-    display: none;
+  display: none;
 }
 
 .session-timeout-container {
-    background-color: #fff;
-    border: 5px solid #0b0c0c;
-    left: 50%;
-    overflow-x: hidden;
-    overflow-y: auto;
-    padding: 30px;
-    position: fixed;
-    top: 50%;
-    transform: translate(-50%,-50%);
-    width: 380px;
-    z-index: 10020;
-    display: none;
+  background-color: #fff;
+  border: 5px solid #0b0c0c;
+  left: 50%;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 30px;
+  position: fixed;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 380px;
+  z-index: 10020;
+  display: none;
 }
 
 #overlay {
-    display: none;
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.5); /* Gray with transparency */
-    z-index: 1040; /* Ensure it is behind the modal but above everything else */
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5); /* Gray with transparency */
+  z-index: 1040; /* Ensure it is behind the modal but above everything else */
 }
 
 .govuk-notification-banner__content > * {
-    box-sizing: border-box;
-    max-width: 100%
+  box-sizing: border-box;
+  max-width: 100%;
 }
 
 .cso-regulator-subtitle {
-    &__label {
-        float: left;
-        margin-inline-start: 0;
-        margin-right: 5px;
-        &::after {
-            content: ":";
-        }
+  &__label {
+    float: left;
+    margin-inline-start: 0;
+    margin-right: 5px;
+    &::after {
+      content: ":";
     }
+  }
 }
 
 .registration-application-block {
-    &__direct-reg-year-title-link {
-        display: flex;
-        flex-direction: column;
-    }
+  &__direct-reg-year-title-link {
+    display: flex;
+    flex-direction: column;
+  }
 }
-
-    

--- a/src/FrontendSchemeRegistration.UI/assets/scss/components/_flash.scss
+++ b/src/FrontendSchemeRegistration.UI/assets/scss/components/_flash.scss
@@ -1,0 +1,30 @@
+.prn-responsive-table {
+  tr.govuk-table__row.border-bottom-0 {
+    border-bottom-width: 0;
+
+    @include govuk-media-query($from: tablet) {
+      border-bottom-width: 2px;
+    }
+  }
+
+  td.govuk-table__cell:has(.flash-container) {
+    padding-left: 0;
+
+    @include govuk-media-query($from: tablet) {
+      padding-left: 0.5rem;
+    }
+  }
+}
+.flash-container {
+  display: inline-block;
+  @include govuk-font($size: 16, $weight: normal);
+  line-height: 1.25rem;
+  margin-bottom: 0.3125rem;
+  padding: 0.3125rem 0.5rem 0.25rem 0.5rem;
+  text-align: left;
+  text-transform: none;
+}
+.flash-container--blue {
+  color: #0c2d4a;
+  background-color: #bbd4ea;
+}

--- a/src/FrontendSchemeRegistration.UI/assets/scss/components/_flash.scss
+++ b/src/FrontendSchemeRegistration.UI/assets/scss/components/_flash.scss
@@ -1,4 +1,8 @@
 .prn-responsive-table {
+  tbody.govuk-table__body:hover {
+      background-color: #f1f1f1;
+  }
+
   tr.govuk-table__row.border-bottom-0 {
     border-bottom-width: 0;
 


### PR DESCRIPTION
### Purpose

Add december waste falsh:
- add flash partial view
- update search prn page view with december waste flash with acceptance years specified only when awaiting approval

### TODO

Add `cy` translations for :
```
	<data name="acceptance_year" xml:space="preserve">
    	<value>Can be accepted towards {0}.</value>
  	</data>
	<data name="acceptance_years" xml:space="preserve">
    	<value>Can be accepted towards {0} or {1}.</value>
  	</data>
  ```

### Screen shots:

| tablet+ > 461 | mobile < 461 |
|--------------|---------------|
| Multiple years: <br /><img width="400" alt="tablet+" src="https://github.com/user-attachments/assets/b5bd5f1f-af9b-4fa2-ad89-93c5471b4b4b" /> <br/ >Single year: <br/>
<img width="400"  alt="localhost_7084_report-data_view-awaiting-acceptance_search= sortBy= filterBy= page=2" src="https://github.com/user-attachments/assets/26cf0dfc-dc7c-45bf-8af1-8984c834f020" /> | <img width="300"  alt="mobile" src="https://github.com/user-attachments/assets/8cf37005-3ba0-4dbc-83b1-f837ad8adbdb" /> |

Hover state:
<img width="400" height="358" alt="Screen Recording 2026-07-28 17 45" src="https://github.com/user-attachments/assets/4c32a609-bc33-4557-94a1-099a0229c6fb" />


