### PR TITLE
Fix: registration file-upload page hanging when the upload fails (e.g. virus scan)

### DIFF
--- a/src/FrontendSchemeRegistration.UI.UnitTests/Controllers/UploadingOrganisationDetailsControllerTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/Controllers/UploadingOrganisationDetailsControllerTests.cs
@@ -177,6 +177,35 @@ public class UploadingOrganisationDetailsControllerTests
     }
 
     [Test]
+    public async Task Get_RedirectsToFileUploadCompanyDetailsGet_WhenUploadHasNotCompletedButContainsErrors()
+    {
+        // Arrange
+        // Simulates a file that failed the antivirus scan (e.g. error code 81, "file contains a virus"):
+        // CompanyDetailsDataComplete never becomes true for such a file, because row validation is
+        // correctly never run against it, so the errors list must be enough to end the polling loop.
+        var submission = new RegistrationSubmission
+        {
+            Id = SubmissionId,
+            CompanyDetailsDataComplete = false,
+            Errors = new List<string> { "81" }
+        };
+
+        _submissionServiceMock
+            .Setup(x => x.GetSubmissionAsync<RegistrationSubmission>(It.IsAny<Guid>()))
+            .ReturnsAsync(submission);
+
+        // Act
+        var result = await _testUploadingOrgDetailsController.Get(SubmissionId) as RedirectToActionResult;
+
+        // Assert
+        result.ActionName.Should().Be("Get");
+        result.ControllerName.Should().Be("FileUploadCompanyDetails");
+        result.RouteValues.Should().HaveCount(3);
+        result.RouteValues.Should().ContainKey("registrationyear");
+        result.RouteValues.Should().ContainKey("submissionId").WhoseValue.Should().Be(SubmissionId.ToString());
+    }
+
+    [Test]
     public async Task Get_ReturnsFileUploadingViewModel_WhenCompanyDetailDataHasNotFinishedProcessing()
     {
         // Arrange

--- a/src/FrontendSchemeRegistration.UI/Controllers/UploadingOrganisationDetailsController.cs
+++ b/src/FrontendSchemeRegistration.UI/Controllers/UploadingOrganisationDetailsController.cs
@@ -50,7 +50,7 @@ public class UploadingOrganisationDetailsController : Controller
             return RedirectToFileUploadCompanyDetails(registrationYear);
         }
 
-        if (!ValidationHasCompleted(submission) || session is null)
+        if ((!ValidationHasCompleted(submission) && !HasFileErrors(submission)) || session is null)
         {
             return GetUploadingOrganisationDetailsViewResult(submissionId, registrationYear, registrationJourney);
         }


### PR DESCRIPTION
UploadingOrganisationDetailsController.Get only left the polling/loading page once CompanyDetailsDataComplete was true. That flag is only ever set by RegistrationSubmissionEventHelper once a RegistrationValidationEvent exists, which correctly never happens for a file that fails the antivirus scan - so the page polled forever for a completion signal that could never arrive.

FileUploadingController (the packaging-data equivalent) already treats a populated Errors list as terminal; apply the same check here so upload-level errors end the polling loop instead of hanging.