### PR TITLE
MO-447: Add extended health check to aid service connectivity issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,11 @@ dotnet run --project tools/translations/cli/cli.csproj -- import --profile decem
 
 Do not create Welsh translations manually. Only import or copy Welsh text from
 an approved source when the English string and UI placement match.
+
+## Aggregate health checks
+
+When adding a downstream health check, inspect the existing client’s
+authentication flow. Do not use delegated-user clients from the header-protected
+anonymous endpoint. Add service-token support only when an existing app-only
+client configuration already exists; otherwise use a dedicated unauthenticated
+named health client and retain the current downstream convention.

--- a/src/FrontendSchemeRegistration.MockServer/WebApi/WebApi.cs
+++ b/src/FrontendSchemeRegistration.MockServer/WebApi/WebApi.cs
@@ -13,6 +13,29 @@ public static class WebApi
     public static WireMockServer WithWebApi(this WireMockServer server, WebApiOptions? options = null)
     {
         options ??= new WebApiOptions();
+
+        server.Given(Request.Create().UsingGet().WithPath("/admin/health"))
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("Healthy"));
+
+        server.Given(Request.Create().UsingGet().WithPath("/admin/health/all"))
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""
+                    {
+                      "status": "Healthy",
+                      "results": {
+                        "WasteObligations": {
+                          "status": "Healthy",
+                          "statusCode": 200,
+                          "response": {
+                            "status": "Healthy",
+                            "results": {}
+                          }
+                        }
+                      }
+                    }
+                    """));
         
         // Actual submission period
         server.Given(Request.Create()

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Infrastructure/ComponentTestClient.cs
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Infrastructure/ComponentTestClient.cs
@@ -26,6 +26,17 @@ public class ComponentTestClient(TestServer server, string baseUrl = "https://lo
         return response;
     }
 
+    public async Task<HttpResponseMessage> GetAsync(string url, IReadOnlyDictionary<string, string> headers)
+    {
+        var request = BuildRequest(url);
+        foreach (var (name, value) in headers)
+        {
+            request.AddHeader(name, value);
+        }
+
+        return await request.GetAsync();
+    }
+
     public override async Task<HttpResponseMessage> PostAsync(string url, Dictionary<string, string> content)
     {
         var getResponse = await GetAsync(url);

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/HealthAllTests.WhenDeepHealthIsRequested_ShouldReturnTheGatewayHealthReport.verified.json
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/HealthAllTests.WhenDeepHealthIsRequested_ShouldReturnTheGatewayHealthReport.verified.json
@@ -1,0 +1,35 @@
+﻿{
+  "status": "Healthy",
+  "results": {
+    "WebApiGateway": {
+      "status": "Healthy",
+      "endpoint": "http://localhost:9091/admin/health/all",
+      "statusCode": 200,
+      "durationMs": "{Scrubbed}",
+      "response": {
+        "status": "Healthy",
+        "results": {
+          "WasteObligations": {
+            "status": "Healthy",
+            "statusCode": 200,
+            "response": {
+              "status": "Healthy"
+            }
+          }
+        }
+      }
+    },
+    "AccountsFacade": {
+      "status": "Healthy",
+      "endpoint": "http://localhost:9091/admin/health",
+      "statusCode": 200,
+      "durationMs": "{Scrubbed}"
+    },
+    "PaymentFacade": {
+      "status": "Healthy",
+      "endpoint": "http://localhost:9091/admin/health",
+      "statusCode": 200,
+      "durationMs": "{Scrubbed}"
+    }
+  }
+}

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/HealthAllTests.WhenShallowHealthIsRequestedWithoutTheDeepQuery_ShouldReturnTheShallowHealthReport.verified.json
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/HealthAllTests.WhenShallowHealthIsRequestedWithoutTheDeepQuery_ShouldReturnTheShallowHealthReport.verified.json
@@ -1,0 +1,23 @@
+﻿{
+  "status": "Healthy",
+  "results": {
+    "WebApiGateway": {
+      "status": "Healthy",
+      "endpoint": "http://localhost:9091/admin/health",
+      "statusCode": 200,
+      "durationMs": "{Scrubbed}"
+    },
+    "AccountsFacade": {
+      "status": "Healthy",
+      "endpoint": "http://localhost:9091/admin/health",
+      "statusCode": 200,
+      "durationMs": "{Scrubbed}"
+    },
+    "PaymentFacade": {
+      "status": "Healthy",
+      "endpoint": "http://localhost:9091/admin/health",
+      "statusCode": 200,
+      "durationMs": "{Scrubbed}"
+    }
+  }
+}

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/HealthAllTests.cs
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/HealthAllTests.cs
@@ -24,6 +24,20 @@ public class HealthAllTests
     }
 
     [Test]
+    public async Task WhenShallowHealthIsRequestedWithoutTheDeepQuery_ShouldReturnTheShallowHealthReport()
+    {
+        var response = await Context.Client.GetAsync(
+            "/admin/health/all",
+            new Dictionary<string, string> { ["X-Health-Check-Token"] = "health-test-token" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await VerifyJson(await response.Content.ReadAsStringAsync())
+            .UseStrictJson()
+            .ScrubMember("durationMs");
+    }
+
+    [Test]
     public async Task WhenDeepHealthIsRequested_ShouldReturnTheGatewayHealthReport()
     {
         var response = await Context.Client.GetAsync(
@@ -35,5 +49,19 @@ public class HealthAllTests
         await VerifyJson(await response.Content.ReadAsStringAsync())
             .UseStrictJson()
             .ScrubMember("durationMs");
+    }
+
+    [Test]
+    public async Task WhenTheHealthHopHeaderIsInvalid_ShouldReturnBadRequest()
+    {
+        var response = await Context.Client.GetAsync(
+            "/admin/health/all?deep=true",
+            new Dictionary<string, string>
+            {
+                ["X-Health-Check-Token"] = "health-test-token",
+                ["X-EPR-Health-Check-Hop"] = "invalid",
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 }

--- a/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/HealthAllTests.cs
+++ b/src/FrontendSchemeRegistration.UI.Component.UnitTests/Tests/HealthAllTests.cs
@@ -1,0 +1,39 @@
+using System.Net;
+using FluentAssertions;
+using FrontendSchemeRegistration.UI.Component.UnitTests.Infrastructure;
+
+namespace FrontendSchemeRegistration.UI.Component.UnitTests.Tests;
+
+public class HealthAllTests
+{
+    private ComponentTestContext Context { get; } = new();
+
+    [SetUp]
+    public void SetUp()
+    {
+        Context.SetUp(additionalConfig: new Dictionary<string, string?>
+        {
+            ["Health:All:Token"] = "health-test-token",
+        });
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Context.Dispose();
+    }
+
+    [Test]
+    public async Task WhenDeepHealthIsRequested_ShouldReturnTheGatewayHealthReport()
+    {
+        var response = await Context.Client.GetAsync(
+            "/admin/health/all?deep=true",
+            new Dictionary<string, string> { ["X-Health-Check-Token"] = "health-test-token" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await VerifyJson(await response.Content.ReadAsStringAsync())
+            .UseStrictJson()
+            .ScrubMember("durationMs");
+    }
+}

--- a/src/FrontendSchemeRegistration.UI.UnitTests/HealthChecks/AggregateHealthHopTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/HealthChecks/AggregateHealthHopTests.cs
@@ -1,0 +1,46 @@
+namespace FrontendSchemeRegistration.UI.UnitTests.HealthChecks;
+
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using UI.HealthChecks;
+
+[TestFixture]
+public class AggregateHealthHopTests
+{
+    [Test]
+    public void TryRead_WhenHeaderIsMissing_StartsAtZero()
+    {
+        var request = new DefaultHttpContext().Request;
+
+        var isValid = AggregateHealthHop.TryRead(request, 2, out var hop);
+
+        isValid.Should().BeTrue();
+        hop.Should().Be(0);
+    }
+
+    [TestCase("-1")]
+    [TestCase("3")]
+    [TestCase("invalid")]
+    [TestCase("999999999999999999999")]
+    public void TryRead_WhenHeaderIsInvalid_ReturnsFalse(string headerValue)
+    {
+        var request = new DefaultHttpContext().Request;
+        request.Headers[AggregateHealthHop.HeaderName] = headerValue;
+
+        var isValid = AggregateHealthHop.TryRead(request, 2, out _);
+
+        isValid.Should().BeFalse();
+    }
+
+    [Test]
+    public void TryRead_WhenHeaderIsRepeated_ReturnsFalse()
+    {
+        var request = new DefaultHttpContext().Request;
+        request.Headers[AggregateHealthHop.HeaderName] = new StringValues(["1", "2"]);
+
+        var isValid = AggregateHealthHop.TryRead(request, 2, out _);
+
+        isValid.Should().BeFalse();
+    }
+}

--- a/src/FrontendSchemeRegistration.UI.UnitTests/HealthChecks/AggregateHealthHopTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/HealthChecks/AggregateHealthHopTests.cs
@@ -19,6 +19,20 @@ public class AggregateHealthHopTests
         hop.Should().Be(0);
     }
 
+    [TestCase(0)]
+    [TestCase(1)]
+    [TestCase(2)]
+    public void TryRead_WhenHeaderIsWithinTheMaximum_ReturnsTheSuppliedHop(int expectedHop)
+    {
+        var request = new DefaultHttpContext().Request;
+        request.Headers[AggregateHealthHop.HeaderName] = expectedHop.ToString();
+
+        var isValid = AggregateHealthHop.TryRead(request, 2, out var hop);
+
+        isValid.Should().BeTrue();
+        hop.Should().Be(expectedHop);
+    }
+
     [TestCase("-1")]
     [TestCase("3")]
     [TestCase("invalid")]

--- a/src/FrontendSchemeRegistration.UI.UnitTests/HealthChecks/HealthAllAccessTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/HealthChecks/HealthAllAccessTests.cs
@@ -1,0 +1,36 @@
+namespace FrontendSchemeRegistration.UI.UnitTests.HealthChecks;
+
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using UI.HealthChecks;
+
+[TestFixture]
+public class HealthAllAccessTests
+{
+    [Test]
+    public void IsValid_WhenHeaderMatchesConfiguredToken_ReturnsTrue()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers["X-Health-Check-Token"] = "expected-token";
+
+        var result = HealthAllAccess.IsValid(context.Request, new HealthAllOptions { Token = "expected-token" });
+
+        result.Should().BeTrue();
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("incorrect-token")]
+    public void IsValid_WhenHeaderIsMissingOrInvalid_ReturnsFalse(string? token)
+    {
+        var context = new DefaultHttpContext();
+        if (token is not null)
+        {
+            context.Request.Headers["X-Health-Check-Token"] = token;
+        }
+
+        var result = HealthAllAccess.IsValid(context.Request, new HealthAllOptions { Token = "expected-token" });
+
+        result.Should().BeFalse();
+    }
+}

--- a/src/FrontendSchemeRegistration.UI.UnitTests/HealthChecks/HealthHttpClientServiceCollectionExtensionsTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/HealthChecks/HealthHttpClientServiceCollectionExtensionsTests.cs
@@ -1,0 +1,30 @@
+namespace FrontendSchemeRegistration.UI.UnitTests.HealthChecks;
+
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using UI.HealthChecks;
+
+[TestFixture]
+public class HealthHttpClientServiceCollectionExtensionsTests
+{
+    [Test]
+    public void AddAggregateHealthHttpClients_RegistersEachNamedClient()
+    {
+        using var serviceProvider = new ServiceCollection()
+            .AddAggregateHealthHttpClients()
+            .BuildServiceProvider();
+        var clientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+
+        foreach (var clientName in new[]
+                 {
+                     DownstreamHealthClientNames.WebApiGateway,
+                     DownstreamHealthClientNames.AccountsFacade,
+                     DownstreamHealthClientNames.PaymentFacade,
+                 })
+        {
+            using var client = clientFactory.CreateClient(clientName);
+
+            client.Should().NotBeNull();
+        }
+    }
+}

--- a/src/FrontendSchemeRegistration.UI.UnitTests/HealthChecks/PackagingFrontendAggregateHealthServiceTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/HealthChecks/PackagingFrontendAggregateHealthServiceTests.cs
@@ -1,0 +1,75 @@
+namespace FrontendSchemeRegistration.UI.UnitTests.HealthChecks;
+
+using System.Collections.Concurrent;
+using System.Net;
+using System.Text;
+using Application.Options;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using UI.HealthChecks;
+
+[TestFixture]
+public class PackagingFrontendAggregateHealthServiceTests
+{
+    [Test]
+    public async Task CheckAsync_WhenNotDeep_CallsShallowHealthEndpoints()
+    {
+        var handler = new RecordingHandler();
+        var service = CreateService(handler);
+
+        var report = await service.CheckAsync(false, CancellationToken.None);
+
+        report.Status.Should().Be("Healthy");
+        handler.RequestUris.Should().BeEquivalentTo(
+            [
+                "https://gateway.test/gateway/admin/health",
+                "https://account.test/account/admin/health",
+                "https://payment.test/payment/admin/health",
+            ]);
+        report.Results["WebApiGateway"].Response.Should().BeNull();
+    }
+
+    [Test]
+    public async Task CheckAsync_WhenDeep_CallsTheGatewayExtendedEndpointOnly()
+    {
+        var handler = new RecordingHandler();
+        var service = CreateService(handler);
+
+        var report = await service.CheckAsync(true, CancellationToken.None);
+
+        handler.RequestUris.Should().Contain("https://gateway.test/gateway/admin/health/all?deep=true");
+        handler.RequestUris.Should().Contain("https://account.test/account/admin/health");
+        handler.RequestUris.Should().Contain("https://payment.test/payment/admin/health");
+        report.Results["WebApiGateway"].Response!.ToJsonString().Should().Be("{\"status\":\"Healthy\",\"results\":{}}");
+    }
+
+    private static PackagingFrontendAggregateHealthService CreateService(RecordingHandler handler) => new(
+        new TestHttpClientFactory(handler),
+        Options.Create(new WebApiOptions { BaseEndpoint = "https://gateway.test/gateway" }),
+        Options.Create(new AccountsFacadeApiOptions { BaseEndpoint = "https://account.test/account/api/" }),
+        Options.Create(new PaymentFacadeApiOptions { BaseUrl = "https://payment.test/payment/api/" }),
+        Options.Create(new HealthAllOptions { Token = "test-token" }));
+
+    private sealed class TestHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public ConcurrentBag<string> RequestUris { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestUris.Add(request.RequestUri!.ToString());
+            var body = request.RequestUri.AbsolutePath.EndsWith("/health/all", StringComparison.Ordinal)
+                ? "{\"status\":\"Healthy\",\"results\":{}}"
+                : "Healthy";
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+}

--- a/src/FrontendSchemeRegistration.UI.UnitTests/HealthChecks/PackagingFrontendAggregateHealthServiceTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/HealthChecks/PackagingFrontendAggregateHealthServiceTests.cs
@@ -32,7 +32,11 @@ public class PackagingFrontendAggregateHealthServiceTests
                 DownstreamHealthClientNames.AccountsFacade,
                 DownstreamHealthClientNames.PaymentFacade,
             ]);
-        report.Results["WebApiGateway"].Response.Should().BeNull();
+        var gatewayResult = report.Results["WebApiGateway"];
+        gatewayResult.Endpoint.Should().Be("https://gateway.test/admin/health");
+        gatewayResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
+        gatewayResult.DurationMs.Should().BeGreaterThanOrEqualTo(0);
+        gatewayResult.Response.Should().BeNull();
     }
 
     [Test]
@@ -77,12 +81,177 @@ public class PackagingFrontendAggregateHealthServiceTests
         report.Results["WebApiGateway"].Response.Should().BeNull();
     }
 
-    private static PackagingFrontendAggregateHealthService CreateService(RecordingHandler handler) => new(
+    [TestCase(HttpStatusCode.Unauthorized)]
+    [TestCase(HttpStatusCode.Forbidden)]
+    public async Task CheckAsync_WhenDownstreamRejectsTheRequest_ReportsAnAuthenticationFailure(HttpStatusCode statusCode)
+    {
+        var handler = new RecordingHandler((_, _) => CreateResponse(statusCode));
+        var service = CreateService(handler);
+
+        var report = await service.CheckAsync(false, 0, CancellationToken.None);
+
+        report.Status.Should().Be("Unhealthy");
+        report.Results.Values.Should().AllSatisfy(result =>
+        {
+            result.Status.Should().Be("Unhealthy");
+            result.Failure.Should().Be("authentication");
+        });
+    }
+
+    [Test]
+    public async Task CheckAsync_WhenTheGatewayReturnsAnUnsuccessfulStatus_ReportsItAsUnhealthy()
+    {
+        var handler = new RecordingHandler((request, _) => CreateResponse(
+            request.RequestUri!.AbsolutePath.EndsWith("/health", StringComparison.Ordinal)
+                ? HttpStatusCode.ServiceUnavailable
+                : HttpStatusCode.OK));
+        var service = CreateService(handler);
+
+        var report = await service.CheckAsync(false, 0, CancellationToken.None);
+
+        report.Status.Should().Be("Unhealthy");
+        report.Results["WebApiGateway"].Status.Should().Be("Unhealthy");
+        report.Results["WebApiGateway"].Failure.Should().BeNull();
+    }
+
+    [Test]
+    public async Task CheckAsync_WhenTheDeepResponseIsNotJson_ReportsAnInvalidResponse()
+    {
+        var handler = new RecordingHandler((request, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                request.RequestUri!.AbsolutePath.EndsWith("/health/all", StringComparison.Ordinal) ? "not json" : "Healthy",
+                Encoding.UTF8,
+                "application/json"),
+        }));
+        var service = CreateService(handler);
+
+        var report = await service.CheckAsync(true, 0, CancellationToken.None);
+
+        report.Status.Should().Be("Unhealthy");
+        report.Results["WebApiGateway"].Failure.Should().Be("invalid_response");
+    }
+
+    [Test]
+    public async Task CheckAsync_WhenTheDeepResponseExceedsTheMaximumSize_ReportsAnInvalidResponse()
+    {
+        var handler = new RecordingHandler((_, _) => CreateResponse(HttpStatusCode.OK, "{\"status\":\"Healthy\"}"));
+        var service = CreateService(handler, healthAllOptions: new HealthAllOptions
+        {
+            Token = "test-token",
+            MaximumResponseBodyBytes = 1,
+        });
+
+        var report = await service.CheckAsync(true, 0, CancellationToken.None);
+
+        report.Status.Should().Be("Unhealthy");
+        report.Results["WebApiGateway"].Failure.Should().Be("invalid_response");
+    }
+
+    [Test]
+    public async Task CheckAsync_WhenTheDeepResponseExceedsTheMaximumSizeWithoutAContentLength_ReportsAnInvalidResponse()
+    {
+        var handler = new RecordingHandler((request, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = request.RequestUri!.AbsolutePath.EndsWith("/health/all", StringComparison.Ordinal)
+                ? new UnknownLengthContent("{\"status\":\"Healthy\"}")
+                : new StringContent("Healthy", Encoding.UTF8, "application/json"),
+        }));
+        var service = CreateService(handler, healthAllOptions: new HealthAllOptions
+        {
+            Token = "test-token",
+            MaximumResponseBodyBytes = 1,
+        });
+
+        var report = await service.CheckAsync(true, 0, CancellationToken.None);
+
+        report.Status.Should().Be("Unhealthy");
+        report.Results["WebApiGateway"].Failure.Should().Be("invalid_response");
+    }
+
+    [Test]
+    public async Task CheckAsync_WhenTheDownstreamIsUnavailable_ReportsItAsUnavailable()
+    {
+        var handler = new RecordingHandler((_, _) => Task.FromException<HttpResponseMessage>(new HttpRequestException()));
+        var service = CreateService(handler);
+
+        var report = await service.CheckAsync(false, 0, CancellationToken.None);
+
+        report.Results.Values.Should().AllSatisfy(result => result.Failure.Should().Be("unavailable"));
+    }
+
+    [Test]
+    public async Task CheckAsync_WhenTheDownstreamTimesOut_ReportsItAsTimedOut()
+    {
+        var handler = new RecordingHandler((_, _) => Task.FromException<HttpResponseMessage>(new OperationCanceledException()));
+        var service = CreateService(handler);
+
+        var report = await service.CheckAsync(false, 0, CancellationToken.None);
+
+        report.Results.Values.Should().AllSatisfy(result => result.Failure.Should().Be("timeout"));
+    }
+
+    [Test]
+    public async Task CheckAsync_WhenTheRequestIsCancelled_PropagatesTheCancellation()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+        var handler = new RecordingHandler((_, cancellationToken) => Task.FromCanceled<HttpResponseMessage>(cancellationToken));
+        var service = CreateService(handler);
+
+        var action = () => service.CheckAsync(false, 0, cancellationTokenSource.Token);
+
+        await action.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Test]
+    public async Task CheckAsync_WhenTheEndpointIsInvalid_ReportsAConfigurationFailure()
+    {
+        var handler = new RecordingHandler();
+        var service = CreateService(handler, webApiOptions: new WebApiOptions { BaseEndpoint = "not-a-url" });
+
+        var report = await service.CheckAsync(false, 0, CancellationToken.None);
+
+        report.Results["WebApiGateway"].Failure.Should().Be("configuration");
+    }
+
+    [Test]
+    public async Task CheckAsync_WhenBuildingTheEndpointFails_ReportsAConfigurationFailure()
+    {
+        var handler = new RecordingHandler();
+        var service = CreateService(handler, webApiOptions: new WebApiOptions { BaseEndpoint = null! });
+
+        var report = await service.CheckAsync(false, 0, CancellationToken.None);
+
+        report.Results["WebApiGateway"].Failure.Should().Be("configuration");
+    }
+
+    [Test]
+    public async Task CheckAsync_WhenAnUnexpectedErrorOccurs_ReportsTheDownstreamAsUnavailable()
+    {
+        var handler = new RecordingHandler((_, _) => Task.FromException<HttpResponseMessage>(new InvalidOperationException()));
+        var service = CreateService(handler);
+
+        var report = await service.CheckAsync(false, 0, CancellationToken.None);
+
+        report.Results.Values.Should().AllSatisfy(result => result.Failure.Should().Be("unavailable"));
+    }
+
+    private static PackagingFrontendAggregateHealthService CreateService(
+        RecordingHandler handler,
+        HealthAllOptions? healthAllOptions = null,
+        WebApiOptions? webApiOptions = null) => new(
         new TestHttpClientFactory(handler),
-        Options.Create(new WebApiOptions { BaseEndpoint = "https://gateway.test/gateway" }),
+        Options.Create(webApiOptions ?? new WebApiOptions { BaseEndpoint = "https://gateway.test/gateway" }),
         Options.Create(new AccountsFacadeApiOptions { BaseEndpoint = "https://account.test/account/api/" }),
         Options.Create(new PaymentFacadeApiOptions { BaseUrl = "https://payment.test/payment/api/v1/" }),
-        Options.Create(new HealthAllOptions { Token = "test-token" }));
+        Options.Create(healthAllOptions ?? new HealthAllOptions { Token = "test-token" }));
+
+    private static Task<HttpResponseMessage> CreateResponse(HttpStatusCode statusCode, string body = "Healthy") =>
+        Task.FromResult(new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        });
 
     private sealed class TestHttpClientFactory(RecordingHandler handler) : IHttpClientFactory
     {
@@ -93,7 +262,8 @@ public class PackagingFrontendAggregateHealthServiceTests
         }
     }
 
-    private sealed class RecordingHandler : HttpMessageHandler
+    private sealed class RecordingHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>? responseFactory = null) : HttpMessageHandler
     {
         public ConcurrentBag<string> RequestUris { get; } = [];
 
@@ -107,6 +277,12 @@ public class PackagingFrontendAggregateHealthServiceTests
             Requests.Add(new RecordedRequest(
                 request.RequestUri.ToString(),
                 request.Headers.TryGetValues(AggregateHealthHop.HeaderName, out var values) ? values.Single() : null));
+
+            if (responseFactory is not null)
+            {
+                return responseFactory(request, cancellationToken);
+            }
+
             var body = request.RequestUri.AbsolutePath.EndsWith("/health/all", StringComparison.Ordinal)
                 ? "{\"status\":\"Healthy\",\"results\":{}}"
                 : "Healthy";
@@ -118,5 +294,19 @@ public class PackagingFrontendAggregateHealthServiceTests
         }
 
         public sealed record RecordedRequest(string Uri, string? Hop);
+    }
+
+    private sealed class UnknownLengthContent(string content) : HttpContent
+    {
+        private readonly byte[] _content = Encoding.UTF8.GetBytes(content);
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+            stream.WriteAsync(_content).AsTask();
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
     }
 }

--- a/src/FrontendSchemeRegistration.UI.UnitTests/HealthChecks/PackagingFrontendAggregateHealthServiceTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/HealthChecks/PackagingFrontendAggregateHealthServiceTests.cs
@@ -26,6 +26,12 @@ public class PackagingFrontendAggregateHealthServiceTests
                 "https://account.test/account/admin/health",
                 "https://payment.test/payment/admin/health",
             ]);
+        handler.ClientNames.Should().BeEquivalentTo(
+            [
+                DownstreamHealthClientNames.WebApiGateway,
+                DownstreamHealthClientNames.AccountsFacade,
+                DownstreamHealthClientNames.PaymentFacade,
+            ]);
         report.Results["WebApiGateway"].Response.Should().BeNull();
     }
 
@@ -50,14 +56,20 @@ public class PackagingFrontendAggregateHealthServiceTests
         Options.Create(new PaymentFacadeApiOptions { BaseUrl = "https://payment.test/payment/api/" }),
         Options.Create(new HealthAllOptions { Token = "test-token" }));
 
-    private sealed class TestHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    private sealed class TestHttpClientFactory(RecordingHandler handler) : IHttpClientFactory
     {
-        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+        public HttpClient CreateClient(string name)
+        {
+            handler.ClientNames.Add(name);
+            return new HttpClient(handler, disposeHandler: false);
+        }
     }
 
     private sealed class RecordingHandler : HttpMessageHandler
     {
         public ConcurrentBag<string> RequestUris { get; } = [];
+
+        public ConcurrentBag<string> ClientNames { get; } = [];
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {

--- a/src/FrontendSchemeRegistration.UI.UnitTests/HealthChecks/PackagingFrontendAggregateHealthServiceTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/HealthChecks/PackagingFrontendAggregateHealthServiceTests.cs
@@ -17,7 +17,7 @@ public class PackagingFrontendAggregateHealthServiceTests
         var handler = new RecordingHandler();
         var service = CreateService(handler);
 
-        var report = await service.CheckAsync(false, CancellationToken.None);
+        var report = await service.CheckAsync(false, 0, CancellationToken.None);
 
         report.Status.Should().Be("Healthy");
         handler.RequestUris.Should().BeEquivalentTo(
@@ -41,12 +41,40 @@ public class PackagingFrontendAggregateHealthServiceTests
         var handler = new RecordingHandler();
         var service = CreateService(handler);
 
-        var report = await service.CheckAsync(true, CancellationToken.None);
+        var report = await service.CheckAsync(true, 0, CancellationToken.None);
 
         handler.RequestUris.Should().Contain("https://gateway.test/gateway/admin/health/all?deep=true");
         handler.RequestUris.Should().Contain("https://account.test/account/admin/health");
         handler.RequestUris.Should().Contain("https://payment.test/payment/admin/health");
+        handler.Requests.Single(request => request.Uri.EndsWith("/health/all?deep=true", StringComparison.Ordinal)).Hop.Should().Be("1");
         report.Results["WebApiGateway"].Response!.ToJsonString().Should().Be("{\"status\":\"Healthy\",\"results\":{}}");
+    }
+
+    [Test]
+    public async Task CheckAsync_WhenDeep_AddsTheNextHopOnlyToTheGateway()
+    {
+        var handler = new RecordingHandler();
+        var service = CreateService(handler);
+
+        await service.CheckAsync(true, 1, CancellationToken.None);
+
+        handler.Requests.Single(request => request.Uri.EndsWith("/health/all?deep=true", StringComparison.Ordinal)).Hop.Should().Be("2");
+        handler.Requests.Where(request => !request.Uri.EndsWith("/health/all?deep=true", StringComparison.Ordinal)).Should().AllSatisfy(request => request.Hop.Should().BeNull());
+    }
+
+    [Test]
+    public async Task CheckAsync_WhenMaximumHopReached_UsesTheGatewayShallowHealth()
+    {
+        var handler = new RecordingHandler();
+        var service = CreateService(handler);
+
+        var report = await service.CheckAsync(true, 2, CancellationToken.None);
+
+        report.DeepLimited.Should().BeTrue();
+        handler.RequestUris.Should().Contain("https://gateway.test/gateway/admin/health");
+        handler.RequestUris.Should().NotContain("https://gateway.test/gateway/admin/health/all?deep=true");
+        handler.Requests.Single(request => request.Uri == "https://gateway.test/gateway/admin/health").Hop.Should().BeNull();
+        report.Results["WebApiGateway"].Response.Should().BeNull();
     }
 
     private static PackagingFrontendAggregateHealthService CreateService(RecordingHandler handler) => new(
@@ -71,9 +99,14 @@ public class PackagingFrontendAggregateHealthServiceTests
 
         public ConcurrentBag<string> ClientNames { get; } = [];
 
+        public ConcurrentBag<RecordedRequest> Requests { get; } = [];
+
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             RequestUris.Add(request.RequestUri!.ToString());
+            Requests.Add(new RecordedRequest(
+                request.RequestUri.ToString(),
+                request.Headers.TryGetValues(AggregateHealthHop.HeaderName, out var values) ? values.Single() : null));
             var body = request.RequestUri.AbsolutePath.EndsWith("/health/all", StringComparison.Ordinal)
                 ? "{\"status\":\"Healthy\",\"results\":{}}"
                 : "Healthy";
@@ -83,5 +116,7 @@ public class PackagingFrontendAggregateHealthServiceTests
                 Content = new StringContent(body, Encoding.UTF8, "application/json"),
             });
         }
+
+        public sealed record RecordedRequest(string Uri, string? Hop);
     }
 }

--- a/src/FrontendSchemeRegistration.UI.UnitTests/HealthChecks/PackagingFrontendAggregateHealthServiceTests.cs
+++ b/src/FrontendSchemeRegistration.UI.UnitTests/HealthChecks/PackagingFrontendAggregateHealthServiceTests.cs
@@ -22,9 +22,9 @@ public class PackagingFrontendAggregateHealthServiceTests
         report.Status.Should().Be("Healthy");
         handler.RequestUris.Should().BeEquivalentTo(
             [
-                "https://gateway.test/gateway/admin/health",
-                "https://account.test/account/admin/health",
-                "https://payment.test/payment/admin/health",
+                "https://gateway.test/admin/health",
+                "https://account.test/admin/health",
+                "https://payment.test/admin/health",
             ]);
         handler.ClientNames.Should().BeEquivalentTo(
             [
@@ -43,9 +43,9 @@ public class PackagingFrontendAggregateHealthServiceTests
 
         var report = await service.CheckAsync(true, 0, CancellationToken.None);
 
-        handler.RequestUris.Should().Contain("https://gateway.test/gateway/admin/health/all?deep=true");
-        handler.RequestUris.Should().Contain("https://account.test/account/admin/health");
-        handler.RequestUris.Should().Contain("https://payment.test/payment/admin/health");
+        handler.RequestUris.Should().Contain("https://gateway.test/admin/health/all?deep=true");
+        handler.RequestUris.Should().Contain("https://account.test/admin/health");
+        handler.RequestUris.Should().Contain("https://payment.test/admin/health");
         handler.Requests.Single(request => request.Uri.EndsWith("/health/all?deep=true", StringComparison.Ordinal)).Hop.Should().Be("1");
         report.Results["WebApiGateway"].Response!.ToJsonString().Should().Be("{\"status\":\"Healthy\",\"results\":{}}");
     }
@@ -71,9 +71,9 @@ public class PackagingFrontendAggregateHealthServiceTests
         var report = await service.CheckAsync(true, 2, CancellationToken.None);
 
         report.DeepLimited.Should().BeTrue();
-        handler.RequestUris.Should().Contain("https://gateway.test/gateway/admin/health");
-        handler.RequestUris.Should().NotContain("https://gateway.test/gateway/admin/health/all?deep=true");
-        handler.Requests.Single(request => request.Uri == "https://gateway.test/gateway/admin/health").Hop.Should().BeNull();
+        handler.RequestUris.Should().Contain("https://gateway.test/admin/health");
+        handler.RequestUris.Should().NotContain("https://gateway.test/admin/health/all?deep=true");
+        handler.Requests.Single(request => request.Uri == "https://gateway.test/admin/health").Hop.Should().BeNull();
         report.Results["WebApiGateway"].Response.Should().BeNull();
     }
 
@@ -81,7 +81,7 @@ public class PackagingFrontendAggregateHealthServiceTests
         new TestHttpClientFactory(handler),
         Options.Create(new WebApiOptions { BaseEndpoint = "https://gateway.test/gateway" }),
         Options.Create(new AccountsFacadeApiOptions { BaseEndpoint = "https://account.test/account/api/" }),
-        Options.Create(new PaymentFacadeApiOptions { BaseUrl = "https://payment.test/payment/api/" }),
+        Options.Create(new PaymentFacadeApiOptions { BaseUrl = "https://payment.test/payment/api/v1/" }),
         Options.Create(new HealthAllOptions { Token = "test-token" }));
 
     private sealed class TestHttpClientFactory(RecordingHandler handler) : IHttpClientFactory

--- a/src/FrontendSchemeRegistration.UI/HealthChecks/AggregateHealthHop.cs
+++ b/src/FrontendSchemeRegistration.UI/HealthChecks/AggregateHealthHop.cs
@@ -1,0 +1,30 @@
+namespace FrontendSchemeRegistration.UI.HealthChecks;
+
+using System.Globalization;
+
+public static class AggregateHealthHop
+{
+    public const string HeaderName = "X-EPR-Health-Check-Hop";
+
+    public static bool TryRead(HttpRequest request, int maximumHops, out int hop)
+    {
+        if (!request.Headers.TryGetValue(HeaderName, out var values))
+        {
+            hop = 0;
+            return true;
+        }
+
+        if (values.Count != 1
+            || !int.TryParse(values[0], NumberStyles.None, CultureInfo.InvariantCulture, out hop)
+            || hop > maximumHops)
+        {
+            hop = 0;
+            return false;
+        }
+
+        return true;
+    }
+
+    public static void AddTo(HttpRequestMessage request, int hop) =>
+        request.Headers.TryAddWithoutValidation(HeaderName, (hop + 1).ToString(CultureInfo.InvariantCulture));
+}

--- a/src/FrontendSchemeRegistration.UI/HealthChecks/DownstreamHealthClientNames.cs
+++ b/src/FrontendSchemeRegistration.UI/HealthChecks/DownstreamHealthClientNames.cs
@@ -1,0 +1,8 @@
+﻿namespace FrontendSchemeRegistration.UI.HealthChecks;
+
+public static class DownstreamHealthClientNames
+{
+    public const string WebApiGateway = "Health.WebApiGateway";
+    public const string AccountsFacade = "Health.AccountsFacade";
+    public const string PaymentFacade = "Health.PaymentFacade";
+}

--- a/src/FrontendSchemeRegistration.UI/HealthChecks/HealthAllAccess.cs
+++ b/src/FrontendSchemeRegistration.UI/HealthChecks/HealthAllAccess.cs
@@ -1,0 +1,23 @@
+namespace FrontendSchemeRegistration.UI.HealthChecks;
+
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+
+public static class HealthAllAccess
+{
+    public static bool IsValid(HttpRequest request, HealthAllOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.Token)
+            || !request.Headers.TryGetValue(options.HeaderName, out var suppliedValues)
+            || suppliedValues.Count != 1)
+        {
+            return false;
+        }
+
+        var supplied = Encoding.UTF8.GetBytes(suppliedValues[0]!);
+        var expected = Encoding.UTF8.GetBytes(options.Token);
+
+        return supplied.Length == expected.Length && CryptographicOperations.FixedTimeEquals(supplied, expected);
+    }
+}

--- a/src/FrontendSchemeRegistration.UI/HealthChecks/HealthAllOptions.cs
+++ b/src/FrontendSchemeRegistration.UI/HealthChecks/HealthAllOptions.cs
@@ -11,4 +11,6 @@ public class HealthAllOptions
     public int DownstreamTimeoutSeconds { get; set; } = 10;
 
     public int MaximumResponseBodyBytes { get; set; } = 65_536;
+
+    public int MaximumDeepHealthHops { get; set; } = 2;
 }

--- a/src/FrontendSchemeRegistration.UI/HealthChecks/HealthAllOptions.cs
+++ b/src/FrontendSchemeRegistration.UI/HealthChecks/HealthAllOptions.cs
@@ -1,0 +1,14 @@
+namespace FrontendSchemeRegistration.UI.HealthChecks;
+
+public class HealthAllOptions
+{
+    public const string ConfigSection = "Health:All";
+
+    public string HeaderName { get; set; } = "X-Health-Check-Token";
+
+    public string Token { get; set; } = string.Empty;
+
+    public int DownstreamTimeoutSeconds { get; set; } = 10;
+
+    public int MaximumResponseBodyBytes { get; set; } = 65_536;
+}

--- a/src/FrontendSchemeRegistration.UI/HealthChecks/HealthHttpClientServiceCollectionExtensions.cs
+++ b/src/FrontendSchemeRegistration.UI/HealthChecks/HealthHttpClientServiceCollectionExtensions.cs
@@ -1,0 +1,19 @@
+﻿namespace FrontendSchemeRegistration.UI.HealthChecks;
+
+public static class HealthHttpClientServiceCollectionExtensions
+{
+    public static IServiceCollection AddAggregateHealthHttpClients(this IServiceCollection services)
+    {
+        AddHealthClient(services, DownstreamHealthClientNames.WebApiGateway);
+        AddHealthClient(services, DownstreamHealthClientNames.AccountsFacade);
+        AddHealthClient(services, DownstreamHealthClientNames.PaymentFacade);
+
+        return services;
+    }
+
+    private static void AddHealthClient(IServiceCollection services, string clientName)
+    {
+        services
+            .AddHttpClient(clientName);
+    }
+}

--- a/src/FrontendSchemeRegistration.UI/HealthChecks/PackagingFrontendAggregateHealthService.cs
+++ b/src/FrontendSchemeRegistration.UI/HealthChecks/PackagingFrontendAggregateHealthService.cs
@@ -1,0 +1,140 @@
+namespace FrontendSchemeRegistration.UI.HealthChecks;
+
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Application.Options;
+using Microsoft.Extensions.Options;
+
+public sealed class PackagingFrontendAggregateHealthService(
+    IHttpClientFactory httpClientFactory,
+    IOptions<WebApiOptions> webApiOptions,
+    IOptions<AccountsFacadeApiOptions> accountsFacadeApiOptions,
+    IOptions<PaymentFacadeApiOptions> paymentFacadeApiOptions,
+    IOptions<HealthAllOptions> healthAllOptions)
+{
+    private const string Healthy = "Healthy";
+    private const string Unhealthy = "Unhealthy";
+
+    public async Task<AggregateHealthReport> CheckAsync(bool deep, CancellationToken cancellationToken)
+    {
+        var checks = new[]
+        {
+            CheckAsync("WebApiGateway", () => WebApiGatewayHealth(webApiOptions.Value.BaseEndpoint, deep), deep, cancellationToken),
+            CheckAsync("AccountsFacade", () => AdminHealth(accountsFacadeApiOptions.Value.BaseEndpoint), false, cancellationToken),
+            CheckAsync("PaymentFacade", () => AdminHealth(paymentFacadeApiOptions.Value.BaseUrl), false, cancellationToken),
+        };
+
+        var results = await Task.WhenAll(checks);
+        var resultMap = results.ToDictionary(result => result.Name, result => result.Result, StringComparer.Ordinal);
+        var status = resultMap.Values.All(result => result.Status == Healthy) ? Healthy : Unhealthy;
+
+        return new AggregateHealthReport(status, resultMap);
+    }
+
+    private async Task<(string Name, DownstreamHealthResult Result)> CheckAsync(
+        string name,
+        Func<Uri> endpointFactory,
+        bool includeResponse,
+        CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(Math.Max(1, healthAllOptions.Value.DownstreamTimeoutSeconds)));
+        Uri? endpoint = null;
+
+        try
+        {
+            endpoint = endpointFactory();
+            using var client = httpClientFactory.CreateClient();
+            using var response = await client.GetAsync(endpoint, HttpCompletionOption.ResponseHeadersRead, timeout.Token);
+            var body = includeResponse ? await ReadJsonResponseAsync(response, timeout.Token) : null;
+            var failure = includeResponse && body is null ? "invalid_response" : null;
+            var isHealthy = response.IsSuccessStatusCode && failure is null;
+
+            return (name, new DownstreamHealthResult(
+                isHealthy ? Healthy : Unhealthy,
+                SafeEndpoint(endpoint),
+                (int)response.StatusCode,
+                stopwatch.ElapsedMilliseconds,
+                body,
+                failure));
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return (name, new DownstreamHealthResult(Unhealthy, SafeEndpoint(endpoint!), null, stopwatch.ElapsedMilliseconds, Failure: "timeout"));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (HttpRequestException)
+        {
+            return (name, new DownstreamHealthResult(Unhealthy, SafeEndpoint(endpoint!), null, stopwatch.ElapsedMilliseconds, Failure: "unavailable"));
+        }
+        catch (UriFormatException)
+        {
+            return (name, new DownstreamHealthResult(Unhealthy, "not configured", null, stopwatch.ElapsedMilliseconds, Failure: "configuration"));
+        }
+        catch (Exception)
+        {
+            return (name, new DownstreamHealthResult(Unhealthy, endpoint is null ? "not configured" : SafeEndpoint(endpoint), null, stopwatch.ElapsedMilliseconds, Failure: endpoint is null ? "configuration" : "unavailable"));
+        }
+    }
+
+    private async Task<JsonNode?> ReadJsonResponseAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        var maxBytes = Math.Max(1, healthAllOptions.Value.MaximumResponseBodyBytes);
+        if (response.Content.Headers.ContentLength is long contentLength && contentLength > maxBytes)
+            return null;
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        await using var buffer = new MemoryStream();
+        var readBuffer = new byte[Math.Min(81920, maxBytes + 1)];
+        while (true)
+        {
+            var bytesToRead = (int)Math.Min(readBuffer.Length, maxBytes - buffer.Length + 1);
+            var bytesRead = await stream.ReadAsync(readBuffer.AsMemory(0, bytesToRead), cancellationToken);
+            if (bytesRead == 0)
+                break;
+
+            await buffer.WriteAsync(readBuffer.AsMemory(0, bytesRead), cancellationToken);
+            if (buffer.Length > maxBytes)
+                return null;
+        }
+
+        try
+        {
+            return JsonNode.Parse(Encoding.UTF8.GetString(buffer.GetBuffer(), 0, (int)buffer.Length));
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static Uri WebApiGatewayHealth(string baseUrl, bool deep) =>
+        new(EnsureTrailingSlash(baseUrl), deep ? "admin/health/all?deep=true" : "admin/health");
+
+    private static Uri AdminHealth(string baseUrl) => new(EnsureTrailingSlash(baseUrl), "../admin/health");
+
+    private static Uri EnsureTrailingSlash(string baseUrl) => new(baseUrl.TrimEnd('/') + "/", UriKind.Absolute);
+
+    private static string SafeEndpoint(Uri endpoint)
+    {
+        var builder = new UriBuilder(endpoint) { UserName = string.Empty, Password = string.Empty, Query = string.Empty };
+        return builder.Uri.ToString();
+    }
+}
+
+public sealed record AggregateHealthReport(string Status, IReadOnlyDictionary<string, DownstreamHealthResult> Results);
+
+public sealed record DownstreamHealthResult(
+    string Status,
+    string Endpoint,
+    int? StatusCode,
+    long DurationMs,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] JsonNode? Response = null,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? Failure = null);

--- a/src/FrontendSchemeRegistration.UI/HealthChecks/PackagingFrontendAggregateHealthService.cs
+++ b/src/FrontendSchemeRegistration.UI/HealthChecks/PackagingFrontendAggregateHealthService.cs
@@ -52,27 +52,15 @@ public sealed class PackagingFrontendAggregateHealthService(
         try
         {
             endpoint = endpointFactory();
-            using var client = httpClientFactory.CreateClient(clientName);
-            using var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
-            if (hop.HasValue)
-            {
-                AggregateHealthHop.AddTo(request, hop.Value);
-            }
-
-            using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeout.Token);
-            var body = includeResponse ? await ReadJsonResponseAsync(response, timeout.Token) : null;
-            var failure = response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden
-                ? "authentication"
-                : includeResponse && body is null ? "invalid_response" : null;
-            var isHealthy = response.IsSuccessStatusCode && failure is null;
+            var response = await SendHealthRequestAsync(clientName, endpoint, includeResponse, hop, timeout.Token);
 
             return (name, new DownstreamHealthResult(
-                isHealthy ? Healthy : Unhealthy,
+                response.IsHealthy ? Healthy : Unhealthy,
                 SafeEndpoint(endpoint),
-                (int)response.StatusCode,
+                response.StatusCode,
                 stopwatch.ElapsedMilliseconds,
-                body,
-                failure));
+                response.Body,
+                response.Failure));
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
@@ -94,6 +82,46 @@ public sealed class PackagingFrontendAggregateHealthService(
         {
             return (name, new DownstreamHealthResult(Unhealthy, endpoint is null ? "not configured" : SafeEndpoint(endpoint), null, stopwatch.ElapsedMilliseconds, Failure: endpoint is null ? "configuration" : "unavailable"));
         }
+    }
+
+    private async Task<HealthCheckResponse> SendHealthRequestAsync(
+        string clientName,
+        Uri endpoint,
+        bool includeResponse,
+        int? hop,
+        CancellationToken cancellationToken)
+    {
+        using var client = httpClientFactory.CreateClient(clientName);
+        using var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
+        if (hop.HasValue)
+        {
+            AggregateHealthHop.AddTo(request, hop.Value);
+        }
+
+        using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        var body = includeResponse ? await ReadJsonResponseAsync(response, cancellationToken) : null;
+        var failure = DetermineFailure(response, includeResponse, body);
+
+        return new HealthCheckResponse(
+            response.IsSuccessStatusCode && failure is null,
+            (int)response.StatusCode,
+            body,
+            failure);
+    }
+
+    private static string? DetermineFailure(HttpResponseMessage response, bool includeResponse, JsonNode? body)
+    {
+        if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+        {
+            return "authentication";
+        }
+
+        if (includeResponse && body is null)
+        {
+            return "invalid_response";
+        }
+
+        return null;
     }
 
     private async Task<JsonNode?> ReadJsonResponseAsync(HttpResponseMessage response, CancellationToken cancellationToken)
@@ -137,6 +165,8 @@ public sealed class PackagingFrontendAggregateHealthService(
         var builder = new UriBuilder(endpoint) { UserName = string.Empty, Password = string.Empty, Query = string.Empty };
         return builder.Uri.ToString();
     }
+
+    private sealed record HealthCheckResponse(bool IsHealthy, int StatusCode, JsonNode? Body, string? Failure);
 }
 
 public sealed record AggregateHealthReport(

--- a/src/FrontendSchemeRegistration.UI/HealthChecks/PackagingFrontendAggregateHealthService.cs
+++ b/src/FrontendSchemeRegistration.UI/HealthChecks/PackagingFrontendAggregateHealthService.cs
@@ -19,20 +19,21 @@ public sealed class PackagingFrontendAggregateHealthService(
     private const string Healthy = "Healthy";
     private const string Unhealthy = "Unhealthy";
 
-    public async Task<AggregateHealthReport> CheckAsync(bool deep, CancellationToken cancellationToken)
+    public async Task<AggregateHealthReport> CheckAsync(bool deep, int hop, CancellationToken cancellationToken)
     {
+        var effectiveDeep = deep && hop < healthAllOptions.Value.MaximumDeepHealthHops;
         var checks = new[]
         {
-            CheckAsync("WebApiGateway", DownstreamHealthClientNames.WebApiGateway, () => WebApiGatewayHealth(webApiOptions.Value.BaseEndpoint, deep), deep, cancellationToken),
-            CheckAsync("AccountsFacade", DownstreamHealthClientNames.AccountsFacade, () => AdminHealth(accountsFacadeApiOptions.Value.BaseEndpoint), false, cancellationToken),
-            CheckAsync("PaymentFacade", DownstreamHealthClientNames.PaymentFacade, () => AdminHealth(paymentFacadeApiOptions.Value.BaseUrl), false, cancellationToken),
+            CheckAsync("WebApiGateway", DownstreamHealthClientNames.WebApiGateway, () => WebApiGatewayHealth(webApiOptions.Value.BaseEndpoint, effectiveDeep), effectiveDeep, effectiveDeep ? hop : null, cancellationToken),
+            CheckAsync("AccountsFacade", DownstreamHealthClientNames.AccountsFacade, () => AdminHealth(accountsFacadeApiOptions.Value.BaseEndpoint), false, null, cancellationToken),
+            CheckAsync("PaymentFacade", DownstreamHealthClientNames.PaymentFacade, () => AdminHealth(paymentFacadeApiOptions.Value.BaseUrl), false, null, cancellationToken),
         };
 
         var results = await Task.WhenAll(checks);
         var resultMap = results.ToDictionary(result => result.Name, result => result.Result, StringComparer.Ordinal);
         var status = resultMap.Values.All(result => result.Status == Healthy) ? Healthy : Unhealthy;
 
-        return new AggregateHealthReport(status, resultMap);
+        return new AggregateHealthReport(status, resultMap, deep && !effectiveDeep);
     }
 
     private async Task<(string Name, DownstreamHealthResult Result)> CheckAsync(
@@ -40,6 +41,7 @@ public sealed class PackagingFrontendAggregateHealthService(
         string clientName,
         Func<Uri> endpointFactory,
         bool includeResponse,
+        int? hop,
         CancellationToken cancellationToken)
     {
         var stopwatch = Stopwatch.StartNew();
@@ -51,7 +53,13 @@ public sealed class PackagingFrontendAggregateHealthService(
         {
             endpoint = endpointFactory();
             using var client = httpClientFactory.CreateClient(clientName);
-            using var response = await client.GetAsync(endpoint, HttpCompletionOption.ResponseHeadersRead, timeout.Token);
+            using var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
+            if (hop.HasValue)
+            {
+                AggregateHealthHop.AddTo(request, hop.Value);
+            }
+
+            using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeout.Token);
             var body = includeResponse ? await ReadJsonResponseAsync(response, timeout.Token) : null;
             var failure = response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden
                 ? "authentication"
@@ -133,7 +141,10 @@ public sealed class PackagingFrontendAggregateHealthService(
     }
 }
 
-public sealed record AggregateHealthReport(string Status, IReadOnlyDictionary<string, DownstreamHealthResult> Results);
+public sealed record AggregateHealthReport(
+    string Status,
+    IReadOnlyDictionary<string, DownstreamHealthResult> Results,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)] bool DeepLimited = false);
 
 public sealed record DownstreamHealthResult(
     string Status,

--- a/src/FrontendSchemeRegistration.UI/HealthChecks/PackagingFrontendAggregateHealthService.cs
+++ b/src/FrontendSchemeRegistration.UI/HealthChecks/PackagingFrontendAggregateHealthService.cs
@@ -1,6 +1,7 @@
 namespace FrontendSchemeRegistration.UI.HealthChecks;
 
 using System.Diagnostics;
+using System.Net;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -22,9 +23,9 @@ public sealed class PackagingFrontendAggregateHealthService(
     {
         var checks = new[]
         {
-            CheckAsync("WebApiGateway", () => WebApiGatewayHealth(webApiOptions.Value.BaseEndpoint, deep), deep, cancellationToken),
-            CheckAsync("AccountsFacade", () => AdminHealth(accountsFacadeApiOptions.Value.BaseEndpoint), false, cancellationToken),
-            CheckAsync("PaymentFacade", () => AdminHealth(paymentFacadeApiOptions.Value.BaseUrl), false, cancellationToken),
+            CheckAsync("WebApiGateway", DownstreamHealthClientNames.WebApiGateway, () => WebApiGatewayHealth(webApiOptions.Value.BaseEndpoint, deep), deep, cancellationToken),
+            CheckAsync("AccountsFacade", DownstreamHealthClientNames.AccountsFacade, () => AdminHealth(accountsFacadeApiOptions.Value.BaseEndpoint), false, cancellationToken),
+            CheckAsync("PaymentFacade", DownstreamHealthClientNames.PaymentFacade, () => AdminHealth(paymentFacadeApiOptions.Value.BaseUrl), false, cancellationToken),
         };
 
         var results = await Task.WhenAll(checks);
@@ -36,6 +37,7 @@ public sealed class PackagingFrontendAggregateHealthService(
 
     private async Task<(string Name, DownstreamHealthResult Result)> CheckAsync(
         string name,
+        string clientName,
         Func<Uri> endpointFactory,
         bool includeResponse,
         CancellationToken cancellationToken)
@@ -48,10 +50,12 @@ public sealed class PackagingFrontendAggregateHealthService(
         try
         {
             endpoint = endpointFactory();
-            using var client = httpClientFactory.CreateClient();
+            using var client = httpClientFactory.CreateClient(clientName);
             using var response = await client.GetAsync(endpoint, HttpCompletionOption.ResponseHeadersRead, timeout.Token);
             var body = includeResponse ? await ReadJsonResponseAsync(response, timeout.Token) : null;
-            var failure = includeResponse && body is null ? "invalid_response" : null;
+            var failure = response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden
+                ? "authentication"
+                : includeResponse && body is null ? "invalid_response" : null;
             var isHealthy = response.IsSuccessStatusCode && failure is null;
 
             return (name, new DownstreamHealthResult(

--- a/src/FrontendSchemeRegistration.UI/HealthChecks/PackagingFrontendAggregateHealthService.cs
+++ b/src/FrontendSchemeRegistration.UI/HealthChecks/PackagingFrontendAggregateHealthService.cs
@@ -128,11 +128,9 @@ public sealed class PackagingFrontendAggregateHealthService(
     }
 
     private static Uri WebApiGatewayHealth(string baseUrl, bool deep) =>
-        new(EnsureTrailingSlash(baseUrl), deep ? "admin/health/all?deep=true" : "admin/health");
+        new(new Uri(baseUrl, UriKind.Absolute), deep ? "/admin/health/all?deep=true" : "/admin/health");
 
-    private static Uri AdminHealth(string baseUrl) => new(EnsureTrailingSlash(baseUrl), "../admin/health");
-
-    private static Uri EnsureTrailingSlash(string baseUrl) => new(baseUrl.TrimEnd('/') + "/", UriKind.Absolute);
+    private static Uri AdminHealth(string baseUrl) => new(new Uri(baseUrl, UriKind.Absolute), "/admin/health");
 
     private static string SafeEndpoint(Uri endpoint)
     {

--- a/src/FrontendSchemeRegistration.UI/Program.cs
+++ b/src/FrontendSchemeRegistration.UI/Program.cs
@@ -1,10 +1,12 @@
 using FrontendSchemeRegistration.Application.ConfigurationExtensions;
 using FrontendSchemeRegistration.Application.Options;
 using FrontendSchemeRegistration.UI.Extensions;
+using FrontendSchemeRegistration.UI.HealthChecks;
 using FrontendSchemeRegistration.UI.Middleware;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Logging;
 using Serilog;
 using CookieOptions = FrontendSchemeRegistration.Application.Options.CookieOptions;
@@ -89,6 +91,8 @@ services.Configure<ForwardedHeadersOptions>(options =>
 });
 
 services.AddHealthChecks();
+services.Configure<HealthAllOptions>(builderConfig.GetSection(HealthAllOptions.ConfigSection));
+services.AddSingleton<PackagingFrontendAggregateHealthService>();
 
 services.AddHsts(options =>
 {
@@ -103,6 +107,19 @@ services.AddWebApiGatewayClient();
 var app = builder.Build();
 
 app.MapHealthChecks("/admin/health").AllowAnonymous();
+app.MapGet(
+        "/admin/health/all",
+        async (bool deep, HttpContext context, IOptions<HealthAllOptions> options, PackagingFrontendAggregateHealthService healthService) =>
+        {
+            if (!HealthAllAccess.IsValid(context.Request, options.Value))
+                return Results.Unauthorized();
+
+            var report = await healthService.CheckAsync(deep, context.RequestAborted);
+            context.Response.Headers.CacheControl = "no-store";
+
+            return Results.Json(report, statusCode: report.Status == "Healthy" ? StatusCodes.Status200OK : StatusCodes.Status503ServiceUnavailable);
+        })
+    .AllowAnonymous();
 
 app.UsePathBase(basePath);
 

--- a/src/FrontendSchemeRegistration.UI/Program.cs
+++ b/src/FrontendSchemeRegistration.UI/Program.cs
@@ -110,12 +110,15 @@ var app = builder.Build();
 app.MapHealthChecks("/admin/health").AllowAnonymous();
 app.MapGet(
         "/admin/health/all",
-        async (bool deep, HttpContext context, IOptions<HealthAllOptions> options, PackagingFrontendAggregateHealthService healthService) =>
+        async (bool? deep, HttpContext context, IOptions<HealthAllOptions> options, PackagingFrontendAggregateHealthService healthService) =>
         {
             if (!HealthAllAccess.IsValid(context.Request, options.Value))
                 return Results.Unauthorized();
 
-            var report = await healthService.CheckAsync(deep, context.RequestAborted);
+            if (!AggregateHealthHop.TryRead(context.Request, options.Value.MaximumDeepHealthHops, out var hop))
+                return Results.BadRequest();
+
+            var report = await healthService.CheckAsync(deep is true, hop, context.RequestAborted);
             context.Response.Headers.CacheControl = "no-store";
 
             return Results.Json(report, statusCode: report.Status == "Healthy" ? StatusCodes.Status200OK : StatusCodes.Status503ServiceUnavailable);

--- a/src/FrontendSchemeRegistration.UI/Program.cs
+++ b/src/FrontendSchemeRegistration.UI/Program.cs
@@ -92,6 +92,7 @@ services.Configure<ForwardedHeadersOptions>(options =>
 
 services.AddHealthChecks();
 services.Configure<HealthAllOptions>(builderConfig.GetSection(HealthAllOptions.ConfigSection));
+services.AddAggregateHealthHttpClients();
 services.AddSingleton<PackagingFrontendAggregateHealthService>();
 
 services.AddHsts(options =>

--- a/src/FrontendSchemeRegistration.UI/appsettings.json
+++ b/src/FrontendSchemeRegistration.UI/appsettings.json
@@ -322,7 +322,8 @@
       "HeaderName": "X-Health-Check-Token",
       "Token": "",
       "DownstreamTimeoutSeconds": 10,
-      "MaximumResponseBodyBytes": 65536
+      "MaximumResponseBodyBytes": 65536,
+      "MaximumDeepHealthHops": 2
     }
   },
   "PaymentFacadeApi": {

--- a/src/FrontendSchemeRegistration.UI/appsettings.json
+++ b/src/FrontendSchemeRegistration.UI/appsettings.json
@@ -317,6 +317,14 @@
     "BaseEndpoint": "https://localhost:7265",
     "DownstreamScope": "https://AZDCUSPOC2.onmicrosoft.com/epr-dev-api-web.file-upload/epr-api-web.file-upload"
   },
+  "Health": {
+    "All": {
+      "HeaderName": "X-Health-Check-Token",
+      "Token": "",
+      "DownstreamTimeoutSeconds": 10,
+      "MaximumResponseBodyBytes": 65536
+    }
+  },
   "PaymentFacadeApi": {
     "BaseUrl": "",
     "DownstreamScope": "",


### PR DESCRIPTION
This PR adds /admin/health/all so all downstream service's health can be assessed.

A deep=true parameter can be passed, which will be passed to downstream calls to services that support it, so there extended health check can be called. This will reveal the dependencies of the downstream itself.

A HTTP header will protect public access to this endpoint. Maximum hops is also passed to downstreams to prevent cyclic dependencies creeping in (we currently don't have any). So a request will terminate after two hops.

Tested in local env. This is the kind of thing we expect to see:

```
GET https://localhost:7084/admin/health/all?deep=true
X-Health-Check-Token: THISISTHETOKEN
```

```json
{
  "status": "Healthy",
  "results": {
    "WebApiGateway": {
      "status": "Healthy",
      "endpoint": "https://epr-pom-api-web:8081/admin/health/all",
      "statusCode": 200,
      "durationMs": 91,
      "response": {
        "status": "Healthy",
        "results": {
          "AccountApi": {
            "status": "Healthy",
            "endpoint": "https://epr-backend-account-microservice:8081/admin/health",
            "statusCode": 200,
            "durationMs": 21
          },
          "SubmissionStatusApi": {
            "status": "Healthy",
            "endpoint": "https://epr-pom-api-submission-status:8081/admin/health",
            "statusCode": 200,
            "durationMs": 8
          },
          "PaymentService": {
            "status": "Healthy",
            "endpoint": "https://epr-payment-facade:8081/admin/health",
            "statusCode": 200,
            "durationMs": 8
          },
          "PrnServiceApi": {
            "status": "Healthy",
            "endpoint": "http://epr-prn-common-backend:8080/admin/health",
            "statusCode": 200,
            "durationMs": 8
          },
          "CommonDataApi": {
            "status": "Healthy",
            "endpoint": "http://epr-common-data-api:8080/admin/health",
            "statusCode": 200,
            "durationMs": 8
          },
          "WasteObligations": {
            "status": "Healthy",
            "endpoint": "http://waste-obligations:8080/health/all",
            "statusCode": 200,
            "durationMs": 59,
            "response": {
              "status": "Degraded",
              "results": {
                "PrnCommonBackend": {
                  "status": "Healthy",
                  "description": "Connected to http://epr-prn-common-backend:8080/admin/health",
                  "data": {
                    "accessToken": {
                      "status": "Retrieved",
                      "requestedScope": "scope",
                      "claimsAvailable": false,
                      "audiences": [],
                      "audienceMatchesRequestedScope": null
                    },
                    "downstream": {
                      "status": "Succeeded",
                      "endpoint": "http://epr-prn-common-backend:8080/admin/health",
                      "statusCode": 200
                    }
                  }
                },
                "WasteOrganisations": {
                  "status": "Healthy",
                  "description": "Connected to http://waste-organisations:8080/health/authorized"
                },
                "GovukNotify": {
                  "status": "Degraded",
                  "description": "Connected to http://wiremock/",
                  "data": {
                    "retrieved": [],
                    "failed": [
                      "b103685d-de8a-4ea9-abc8-d244ca26841b",
                      "95d8c2aa-a229-4ecb-9774-78ec06d0cbac",
                      "5f64e3bd-d454-4a45-a9c6-9409bf940d7a",
                      "b3223b0b-a467-40c1-9150-f78b76d11fd8"
                    ]
                  }
                },
                "AnalyticsAuditEventTopic": {
                  "status": "Healthy",
                  "description": "Connected to AWS topic: arn:aws:sns:eu-west-2:000000000000:waste_obligations_analytics_events"
                },
                "AnalyticsAuditEventQueue": {
                  "status": "Healthy",
                  "description": "Connected to AWS queue: http://floci:4566/000000000000/waste_obligations_analytics_events_queue"
                }
              }
            }
          }
        }
      }
    },
    "AccountsFacade": {
      "status": "Healthy",
      "endpoint": "https://epr-facade-account-microservice:8081/admin/health",
      "statusCode": 200,
      "durationMs": 4
    },
    "PaymentFacade": {
      "status": "Healthy",
      "endpoint": "https://epr-payment-facade:8081/admin/health",
      "statusCode": 200,
      "durationMs": 7
    }
  }
}
```